### PR TITLE
Fix DEDataArray dependency

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -5,6 +5,7 @@ version = "0.4.9"
 
 [deps]
 AdvancedMH = "5b7e9947-ddc0-4b3f-9b55-0d8042f74170"
+DEDataArrays = "754358af-613d-5f8d-9788-280bf1605d4c"
 DiffEqBase = "2b5f629d-d688-5b77-993f-72d75c75574e"
 DiffEqCallbacks = "459566f4-90b8-5000-8ac3-15dfb0a30def"
 Distributions = "31c24e10-a181-5473-b8eb-7969acd0382f"
@@ -40,6 +41,7 @@ UnitfulRecipes = "42071c24-d89e-48dd-8a24-8a12d9b8861f"
 
 [compat]
 AdvancedMH = "0.6"
+DEDataArrays = "0.2"
 DiffEqBase = "6"
 DiffEqCallbacks = "2.16"
 Distributions = "0.25"
@@ -70,7 +72,7 @@ UnPack = "1"
 Unitful = "1"
 UnitfulAtomic = "1"
 UnitfulRecipes = "1"
-julia= "1"
+julia = "1"
 
 [extras]
 DiffEqDevTools = "f3b72e0c-5b89-59e1-b016-84e28bfd966d"

--- a/src/dynamical_variables.jl
+++ b/src/dynamical_variables.jl
@@ -1,6 +1,6 @@
 
 using RecursiveArrayTools
-using DiffEqBase
+using DEDataArrays
 
 export DynamicalVariables
 export get_positions


### PR DESCRIPTION
DEDataArrays have been separated from DiffEqBase into DEDataArrays. This fixes the imports to work with the latest versions.