### PR TITLE
Ensure callbacks are properly assigned

### DIFF
--- a/src/Dynamics/Dynamics.jl
+++ b/src/Dynamics/Dynamics.jl
@@ -78,7 +78,8 @@ end
 """
 Provides the DEProblem for each type of simulation.
 """
-create_problem(u0, tspan, sim) = ODEProblem(motion!, u0, tspan, sim)
+create_problem(u0, tspan, sim) =
+    ODEProblem(motion!, u0, tspan, sim; callback=get_callbacks(sim))
 
 select_algorithm(::AbstractSimulation) = VCABM5()
 get_callbacks(::AbstractSimulation) = nothing

--- a/src/Dynamics/SurfaceHopping/SurfaceHopping.jl
+++ b/src/Dynamics/SurfaceHopping/SurfaceHopping.jl
@@ -78,7 +78,7 @@ rescale_velocity!(::AbstractSimulation{<:SurfaceHopping}, u) = true
 
 function create_problem(u0, tspan, sim::AbstractSimulation{<:SurfaceHopping})
     set_state!(sim.method, u0.state)
-    ODEProblem(motion!, u0, tspan, sim)
+    ODEProblem(motion!, u0, tspan, sim; callback=get_callbacks(sim))
 end
 
 include("surface_hopping_variables.jl")

--- a/src/Ensembles/Ensembles.jl
+++ b/src/Ensembles/Ensembles.jl
@@ -64,7 +64,6 @@ function run_ensemble(
 
     u0 = select_u0(sim, rand(selection.distribution)..., selection.distribution.state, selection.distribution.type)
     problem = Dynamics.create_problem(u0, austrip.(tspan), sim)
-    problem = remake(problem, callback=Dynamics.get_callbacks(sim))
 
     if hasfield(typeof(reduction), :u_init)
         u_init = reduction.u_init
@@ -95,8 +94,6 @@ function run_ensemble_standard_output(
             selection.distribution.state, selection.distribution.type),
         austrip.(tspan),
         sim)
-
-    problem = remake(problem, callback=Dynamics.get_callbacks(sim))
 
     new_selection = SelectWithCallbacks(selection, Dynamics.get_callbacks(sim), output, kwargs[:trajectories], saveat=saveat)
 


### PR DESCRIPTION
@wgst found a bug with surface hopping where the callbacks were not being used properly during ensemble simulations. This was happening due to a recent change where instead of using `remake` to modify the problems we were creating a new problem. However, the new problem did not have the callbacks assigned correctly.

This fixes the issue by making sure the `create_problem` function attaches the callbacks.