### PR TITLE
Refactor ensemble outputs

### DIFF
--- a/test/Ensembles/reductions.jl
+++ b/test/Ensembles/reductions.jl
@@ -3,16 +3,16 @@ using NQCDynamics
 using Test
 using OrdinaryDiffEq
 
-@testset "select_reduction" begin
-    @test Ensembles.select_reduction(:mean) isa Ensembles.MeanReduction
-    @test Ensembles.select_reduction(:sum) isa Ensembles.SumReduction
-    @test Ensembles.select_reduction(:append) isa Function
+@testset "Reduction" begin
+    @test Ensembles.Reduction(:mean) isa Ensembles.MeanReduction
+    @test Ensembles.Reduction(:sum) isa Ensembles.SumReduction
+    @test Ensembles.Reduction(:append) isa Ensembles.AppendReduction
 end
 
 @testset "get_u_init" begin
 
     @testset "Output, reduction=$reduction" for reduction in (:mean, :sum)
-        reduction = Ensembles.select_reduction(reduction)
+        reduction = Ensembles.Reduction(reduction)
         tspan = (0.0, 1.0)
         u0 = 1.0
         saveat = 1
@@ -22,16 +22,16 @@ end
     end
 
     @testset "reduction=:append" begin
-        reduction = Ensembles.select_reduction(:append)
+        reduction = Ensembles.Reduction(:append)
         output = Ensembles.OutputFinal()
         u0 = 1
         saveat = 1
         u_init = Ensembles.get_u_init(reduction, saveat, Dict(), (0, 1), u0, output)
-        @test u_init == []
+        @test u_init === nothing
     end
 
     @testset "TimeCorrelationFunction, reduction=$reduction" for reduction in (:mean, :sum)
-        reduction = Ensembles.select_reduction(reduction)
+        reduction = Ensembles.Reduction(reduction)
         sim = Simulation{FSSH}(Atoms(1), DoubleWell())
         saveat = 0.1
         tspan = (0.0, 1.0)

--- a/test/Ensembles/selections.jl
+++ b/test/Ensembles/selections.jl
@@ -29,8 +29,3 @@ end
     selector = Ensembles.RandomSelection(distribution)
     new_prob = selector(prob, 3, false)
 end
-
-@testset "SelectWithCallbacks" begin
-    selector = Ensembles.RandomSelection(distribution)
-    Ensembles.SelectWithCallbacks(selector, CallbackSet(), (:position,), 10)
-end


### PR DESCRIPTION
The existing procedure involves attempting to use the saving callbacks from the single trajectory case similarly for the ensemble outputs as well. This was fine but it doesn't work when using EnsembleDistributed.

In this PR I've reworked the saving to instead rely up the standard diffeq output+reduction setup. This means it'll now work in parallel and the code is a bit cleaner.

The only downside is that it will require recalculation of some quantities such as forces after the trajectory has finished. But the ensemble workflow isn't really intended for that purpose so this should be fine.