### PR TITLE
Use new iterators and small performance update

### DIFF
--- a/src/Calculators/Calculators.jl
+++ b/src/Calculators/Calculators.jl
@@ -39,6 +39,13 @@ abstract type AbstractDiabaticCalculator{T,M<:Union{DiabaticFrictionModel,Diabat
 abstract type AbstractStaticDiabaticCalculator{T,M} <: AbstractDiabaticCalculator{T,M} end
 abstract type AbstractFrictionCalculator{T,M<:AdiabaticFrictionModel} <: AbstractCalculator{T,M} end
 
+NQCModels.nstates(calc::AbstractCalculator) = NQCModels.nstates(calc.model)
+NQCModels.eachstate(calc::AbstractCalculator) = NQCModels.eachstate(calc.model)
+NQCModels.nelectrons(calc::AbstractCalculator) = NQCModels.nelectrons(calc.model)
+NQCModels.eachelectron(calc::AbstractCalculator) = NQCModels.eachelectron(calc.model)
+NQCModels.mobileatoms(calc::AbstractCalculator) = NQCModels.mobileatoms(calc.model, size(calc.derivative, 2))
+NQCModels.dofs(calc::AbstractCalculator) = NQCModels.dofs(calc.model)
+
 Base.eltype(::AbstractCalculator{T}) where {T} = T
 
 mutable struct DependentField{V,R}

--- a/src/simulations.jl
+++ b/src/simulations.jl
@@ -59,7 +59,12 @@ function RingPolymerSimulation(atoms::Atoms, model::Model, method::M, n_beads::I
     RingPolymerSimulation(temperature, cell, atoms, model, method, n_beads, quantum_nuclei)
 end
 
-NQCModels.nstates(sim::AbstractSimulation) = NQCModels.nstates(sim.calculator.model)
+NQCModels.nstates(sim::AbstractSimulation) = NQCModels.nstates(sim.calculator)
+NQCModels.eachstate(sim::AbstractSimulation) = NQCModels.eachstate(sim.calculator)
+NQCModels.nelectrons(sim::AbstractSimulation) = NQCModels.nelectrons(sim.calculator)
+NQCModels.eachelectron(sim::AbstractSimulation) = NQCModels.eachelectron(sim.calculator)
+NQCModels.mobileatoms(sim::AbstractSimulation) = NQCModels.mobileatoms(sim.calculator)
+NQCModels.dofs(sim::AbstractSimulation) = NQCModels.dofs(sim.calculator)
 
 NQCModels.ndofs(sim::AbstractSimulation) = NQCModels.ndofs(sim.calculator.model)
 natoms(sim::AbstractSimulation) = length(sim.atoms)


### PR DESCRIPTION
NQCModels.jl now has a few more iterators we can use. We can now use these to iterate through states/electrons more easily.

I've also slightly rewritten the nonadiabatic coupling evaluation code for improved performance.