### PR TITLE
Add BCB algorithm for adiabatic ring polymer dynamics and refactor algorithm declarations

### DIFF
--- a/src/DynamicsMethods/ClassicalMethods/classical.jl
+++ b/src/DynamicsMethods/ClassicalMethods/classical.jl
@@ -74,8 +74,8 @@ function DynamicsMethods.create_problem(u0, tspan::Tuple, sim::Simulation{<:Clas
         DynamicsUtils.get_velocities(u0), DynamicsUtils.get_positions(u0), tspan, sim)
 end
 
-function DynamicsMethods.create_problem(u0, tspan::Tuple, sim::RingPolymerSimulation{<:Classical})
-    OrdinaryDiffEq.DynamicalODEProblem(ring_polymer_acceleration!, DynamicsUtils.velocity!,
+function DynamicsMethods.create_problem(u0, tspan::Tuple, sim::RingPolymerSimulation{Classical})
+    OrdinaryDiffEq.DynamicalODEProblem(acceleration!, DynamicsUtils.velocity!,
         DynamicsUtils.get_velocities(u0), DynamicsUtils.get_positions(u0), tspan, sim)
 end
 

--- a/src/DynamicsMethods/DynamicsMethods.jl
+++ b/src/DynamicsMethods/DynamicsMethods.jl
@@ -112,6 +112,7 @@ function run_trajectory(u0, tspan::Tuple, sim::AbstractSimulation;
     @info "Performing a single trajectory."
     stats = @timed DiffEqBase.solve(problem, algorithm; stripped_kwargs...)
     @info "Finished after $(stats.time) seconds."
+    @debug "Integration algorithm: $(stats.value.alg)"
     out = [(;zip(output, val)...) for val in vals.saveval]
     TypedTables.Table(t=vals.t, out)
 end

--- a/src/DynamicsMethods/IntegrationAlgorithms/IntegrationAlgorithms.jl
+++ b/src/DynamicsMethods/IntegrationAlgorithms/IntegrationAlgorithms.jl
@@ -1,7 +1,7 @@
 
 module IntegrationAlgorithms
 
-using ....NQCDynamics:
+using NQCDynamics:
     NQCDynamics,
     AbstractSimulation,
     Simulation,
@@ -11,10 +11,60 @@ using ....NQCDynamics:
     Calculators,
     natoms, nbeads, ndofs
 
+using OrdinaryDiffEq: OrdinaryDiffEq
+using StochasticDiffEq: StochasticDiffEq
+
+struct BCB <: OrdinaryDiffEq.OrdinaryDiffEqAlgorithm end
+struct BCBwithTsit5 <: OrdinaryDiffEq.OrdinaryDiffEqAlgorithm end
+
+"""
+    RingPolymerMInt <: OrdinaryDiffEq.OrdinaryDiffEqAlgorithm
+
+Second order symplectic momentum integral algorithm applied to NRPMD.
+
+# Reference
+
+[J. Chem. Phys. 148, 102326 (2018)](https://doi.org/10.1063/1.5005557)
+"""
+struct RingPolymerMInt <: OrdinaryDiffEq.OrdinaryDiffEqAlgorithm end
+
+"""
+    MInt <: OrdinaryDiffEq.OrdinaryDiffEqAlgorithm
+
+Second order symplectic momentum integral algorithm.
+
+# Reference
+
+[J. Chem. Phys. 148, 102326 (2018)](https://doi.org/10.1063/1.5005557)
+"""
+struct MInt <: OrdinaryDiffEq.OrdinaryDiffEqAlgorithm end
+
+struct MDEF_BAOAB <: StochasticDiffEq.StochasticDiffEqAlgorithm end
+struct BCOCB <: StochasticDiffEq.StochasticDiffEqAlgorithm end
+
+DynamicsMethods.select_algorithm(::RingPolymerSimulation{<:DynamicsMethods.SurfaceHoppingMethods.SurfaceHopping}) = BCBwithTsit5()
+DynamicsMethods.select_algorithm(::RingPolymerSimulation{<:DynamicsMethods.EhrenfestMethods.AbstractEhrenfest}) = BCBwithTsit5()
+DynamicsMethods.select_algorithm(::Simulation{<:DynamicsMethods.ClassicalMethods.AbstractMDEF}) = MDEF_BAOAB()
+DynamicsMethods.select_algorithm(::RingPolymerSimulation{<:DynamicsMethods.ClassicalMethods.AbstractMDEF}) = BCOCB()
+DynamicsMethods.select_algorithm(::RingPolymerSimulation{<:DynamicsMethods.ClassicalMethods.ThermalLangevin}) = BCOCB()
+DynamicsMethods.select_algorithm(::Simulation{<:DynamicsMethods.MappingVariableMethods.SpinMappingW}) = MInt()
+DynamicsMethods.select_algorithm(::RingPolymerSimulation{<:DynamicsMethods.MappingVariableMethods.NRPMD}) = RingPolymerMInt()
+DynamicsMethods.select_algorithm(::RingPolymerSimulation{<:DynamicsMethods.MappingVariableMethods.eCMM}) = RingPolymerMInt()
+DynamicsMethods.select_algorithm(::RingPolymerSimulation{DynamicsMethods.ClassicalMethods.Classical}) = BCB()
+
+export BCB
+export BCBwithTsit5
+export RingPolymerMInt
+export MInt
+export MDEF_BAOAB
+export BCOCB
+
 include("mdef_baoab.jl")
 include("bcocb.jl")
 include("mint.jl")
 include("ringpolymer_mint.jl")
 include("bcb_electronics.jl")
+include("bcb.jl")
+include("steps.jl")
 
 end # module

--- a/src/DynamicsMethods/IntegrationAlgorithms/bcb.jl
+++ b/src/DynamicsMethods/IntegrationAlgorithms/bcb.jl
@@ -1,0 +1,67 @@
+
+mutable struct BCBCache{uType,rateType,uEltypeNoUnits} <: OrdinaryDiffEq.OrdinaryDiffEqMutableCache
+    u::uType
+    uprev::uType
+    tmp::uType
+    k::rateType
+    fsalfirst::rateType
+    halfdt::uEltypeNoUnits
+    cayley::Vector{Matrix{uEltypeNoUnits}}
+end
+
+function OrdinaryDiffEq.alg_cache(::BCB,u,rate_prototype,::Type{uEltypeNoUnits},::Type{uBottomEltypeNoUnits},::Type{tTypeNoUnits},uprev,uprev2,f,t,dt,reltol,p,calck,::Val{true}) where {uEltypeNoUnits,uBottomEltypeNoUnits,tTypeNoUnits}
+    tmp = zero(rate_prototype)
+    k = zero(rate_prototype)
+    fsalfirst = zero(rate_prototype)
+    halfdt = dt / 2
+    cayley = RingPolymers.cayley_propagator(p.beads, dt; half=false)
+    BCBCache(u, uprev, k, tmp, fsalfirst, halfdt, cayley)
+end
+
+function OrdinaryDiffEq.verify_f2(f, res, p, q, pa, t, integrator, ::BCBCache)
+    f(res, p, q, pa, t)
+    res == p ? res : OrdinaryDiffEq.throwex(integrator)
+end
+
+function OrdinaryDiffEq.initialize!(integrator, cache::BCBCache)
+    integrator.fsalfirst = cache.fsalfirst
+    integrator.fsallast = cache.k
+  
+    integrator.kshortsize = 2
+    resize!(integrator.k, integrator.kshortsize)
+    integrator.k[1] = integrator.fsalfirst
+    integrator.k[2] = integrator.fsallast
+  
+    duprev,uprev = integrator.uprev.x
+    integrator.f.f1(integrator.k[2].x[1],duprev,uprev,integrator.p,integrator.t)
+    OrdinaryDiffEq.verify_f2(integrator.f.f2, integrator.k[2].x[2], duprev, uprev, integrator.p, integrator.t, integrator, cache)
+    integrator.destats.nf += 1
+    integrator.destats.nf2 += 1
+end
+
+@muladd function OrdinaryDiffEq.perform_step!(integrator, cache::BCBCache, repeat_step=false)
+    @unpack t, dt, p = integrator
+    (;cayley, halfdt) = cache
+
+    vprev, rprev, acceleration = OrdinaryDiffEq.load_symp_state(integrator)
+    v, r, vtmp = OrdinaryDiffEq.alloc_symp_state(integrator)
+
+    copy!(r, rprev)
+
+    step_B!(vtmp, vprev, halfdt, acceleration)
+
+    RingPolymerArrays.transform_to_normal_modes!(vtmp, p.beads.transformation)
+    RingPolymerArrays.transform_to_normal_modes!(r, p.beads.transformation)
+
+    step_C!(vtmp, r, cayley)
+
+    RingPolymerArrays.transform_from_normal_modes!(vtmp, p.beads.transformation)
+    RingPolymerArrays.transform_from_normal_modes!(r, p.beads.transformation)
+
+    integrator.f.f1(acceleration, vtmp, r, p, t)
+    integrator.destats.nf += 1
+
+    step_B!(v, vtmp, halfdt, acceleration)
+
+    OrdinaryDiffEq.store_symp_state!(integrator, cache, acceleration, v)
+end

--- a/src/DynamicsMethods/IntegrationAlgorithms/bcb_electronics.jl
+++ b/src/DynamicsMethods/IntegrationAlgorithms/bcb_electronics.jl
@@ -1,7 +1,5 @@
 using RingPolymerArrays: RingPolymerArrays
 
-struct BCBwithTsit5 <: OrdinaryDiffEq.OrdinaryDiffEqAlgorithm end
-
 OrdinaryDiffEq.isfsal(::BCBwithTsit5) = false
 
 mutable struct BCBwithTsit5Cache{uType,rType,vType,rateType,uEltypeNoUnits,T} <: OrdinaryDiffEq.OrdinaryDiffEqMutableCache
@@ -91,6 +89,3 @@ end
     integrator.destats.nf += 6
 
 end
-
-DynamicsMethods.select_algorithm(::RingPolymerSimulation{<:DynamicsMethods.SurfaceHoppingMethods.SurfaceHopping}) = BCBwithTsit5()
-DynamicsMethods.select_algorithm(::RingPolymerSimulation{<:DynamicsMethods.EhrenfestMethods.AbstractEhrenfest}) = BCBwithTsit5()

--- a/src/DynamicsMethods/IntegrationAlgorithms/mint.jl
+++ b/src/DynamicsMethods/IntegrationAlgorithms/mint.jl
@@ -2,22 +2,10 @@
 using UnPack: @unpack
 using MuladdMacro: @muladd
 using StaticArrays: SMatrix
-using OrdinaryDiffEq: OrdinaryDiffEq
 using LinearAlgebra: Hermitian, tr, Eigen, dot
 
 using NQCDynamics.DynamicsMethods: MappingVariableMethods
 using NQCModels: nstates, NQCModels
-
-"""
-    MInt <: OrdinaryDiffEq.OrdinaryDiffEqAlgorithm
-
-Second order symplectic momentum integral algorithm.
-
-# Reference
-
-[J. Chem. Phys. 148, 102326 (2018)](https://doi.org/10.1063/1.5005557)
-"""
-struct MInt <: OrdinaryDiffEq.OrdinaryDiffEqAlgorithm end
 
 OrdinaryDiffEq.isfsal(::MInt) = false
 
@@ -187,5 +175,3 @@ function get_mapping_nuclear_force(q::AbstractVector, p::AbstractVector,
     force -= 2dot(q, tmp_vec)
     return force / 2
 end
-
-DynamicsMethods.select_algorithm(::Simulation{<:MappingVariableMethods.SpinMappingW}) = MInt()

--- a/src/DynamicsMethods/IntegrationAlgorithms/ringpolymer_mint.jl
+++ b/src/DynamicsMethods/IntegrationAlgorithms/ringpolymer_mint.jl
@@ -2,22 +2,10 @@
 using UnPack: @unpack
 using MuladdMacro: @muladd
 using StaticArrays: SMatrix
-using OrdinaryDiffEq: OrdinaryDiffEq
 using LinearAlgebra: Hermitian, tr
 
 using NQCDynamics.DynamicsMethods: MappingVariableMethods
 using NQCModels: nstates
-
-"""
-    RingPolymerMInt <: OrdinaryDiffEq.OrdinaryDiffEqAlgorithm
-
-Second order symplectic momentum integral algorithm applied to NRPMD.
-
-# Reference
-
-[J. Chem. Phys. 148, 102326 (2018)](https://doi.org/10.1063/1.5005557)
-"""
-struct RingPolymerMInt <: OrdinaryDiffEq.OrdinaryDiffEqAlgorithm end
 
 OrdinaryDiffEq.isfsal(::RingPolymerMInt) = false
 
@@ -88,15 +76,6 @@ function OrdinaryDiffEq.initialize!(_, ::RingPolymerMIntCache) end
 
 end
 
-function step_C!(v::AbstractArray{T,3}, r::AbstractArray{T,3}, cayley::Vector{<:AbstractMatrix}) where {T}
-    for I in CartesianIndices(v)
-        rtmp = cayley[I[3]][1,1] * r[I] + cayley[I[3]][1,2] * v[I]
-        vtmp = cayley[I[3]][2,1] * r[I] + cayley[I[3]][2,2] * v[I]
-        r[I] = rtmp
-        v[I] = vtmp
-    end
-end
-
 function propagate_mapping_variables!(calc, u, dt)
     for i=1:length(calc.eigen)
         V̄ = tr(calc.potential[i]) / nstates(calc.model)
@@ -149,6 +128,3 @@ function get_mapping_nuclear_force(q::AbstractVector, p::AbstractVector,
                            E::AbstractMatrix, F::AbstractMatrix)
     return 0.5 * (q'*E*q + p'*E*p) - q'*F*p
 end
-
-DynamicsMethods.select_algorithm(::RingPolymerSimulation{<:MappingVariableMethods.NRPMD}) = RingPolymerMInt()
-DynamicsMethods.select_algorithm(::RingPolymerSimulation{<:MappingVariableMethods.eCMM}) = RingPolymerMInt()

--- a/src/DynamicsMethods/IntegrationAlgorithms/steps.jl
+++ b/src/DynamicsMethods/IntegrationAlgorithms/steps.jl
@@ -109,7 +109,7 @@ function step_O!(friction::LangevinCache, integrator, v::RingPolymerArray, r::Ri
     @unpack W, p, dt, sqdt = integrator
     @unpack c1, c2, sqrtmass, σ = friction
 
-    @.. σ = sqrt(get_ring_polymer_temperature(p, t)) * sqrtmass
+    @.. σ = sqrt(get_temperature(p, t)) * sqrtmass
 
     for i in axes(r, 3)
         for j in RingPolymerArrays.quantumindices(v)

--- a/src/DynamicsMethods/IntegrationAlgorithms/steps.jl
+++ b/src/DynamicsMethods/IntegrationAlgorithms/steps.jl
@@ -1,0 +1,125 @@
+
+function step_B!(v2, v1, dt, k)
+    @.. broadcast=false v2 = muladd(dt, k, v1)
+end
+function step_A!(r2, r1, dt, v)
+    @.. broadcast=false r2 = muladd(dt, v, r1)
+end
+
+function step_C!(v::AbstractArray{T,3}, r::AbstractArray{T,3}, cayley::Vector{<:AbstractMatrix}) where {T}
+    for I in CartesianIndices(v)
+        rtmp = cayley[I[3]][1,1] * r[I] + cayley[I[3]][1,2] * v[I]
+        vtmp = cayley[I[3]][2,1] * r[I] + cayley[I[3]][2,2] * v[I]
+        r[I] = rtmp
+        v[I] = vtmp
+    end
+end
+
+function step_C!(v::RingPolymerArray, r::RingPolymerArray, cayley::Vector{<:Matrix})
+    for i in axes(r, 3)
+        for j in RingPolymerArrays.quantumindices(v)
+            for k in axes(r, 1)
+                rtmp = cayley[i][1,1] * r[k,j,i] + cayley[i][1,2] * v[k,j,i]
+                vtmp = cayley[i][2,1] * r[k,j,i] + cayley[i][2,2] * v[k,j,i]
+                r[k,j,i] = rtmp
+                v[k,j,i] = vtmp
+            end
+        end
+    end
+
+    for j in RingPolymerArrays.classicalindices(v)
+        for k in axes(r, 1)
+            rtmp = cayley[1][1,1] * r[k,j,1] + cayley[1][1,2] * v[k,j,1]
+            vtmp = cayley[1][2,1] * r[k,j,1] + cayley[1][2,2] * v[k,j,1]
+            r[k,j,1] = rtmp
+            v[k,j,1] = vtmp
+        end
+    end
+end
+
+function step_O!(cache, integrator)
+    @unpack t, dt, W, p, sqdt = integrator
+    @unpack dutmp, flatdutmp, tmp1, tmp2, gtmp, noise, half, c1, c2 = cache
+
+    Λ = gtmp
+    σ = sqrt(get_temperature(p, t+dt*half)) ./ sqrt.(repeat(p.atoms.masses; inner=ndofs(p)))
+
+    @.. noise = σ*W.dW[:] / sqdt
+
+    γ, c = LAPACK.syev!('V', 'U', Λ) # symmetric eigen
+    clamp!(γ, 0, Inf)
+    for (j,i) in enumerate(diagind(c1))
+        c1[i] = exp(-γ[j]*dt)
+        c2[i] = sqrt(1 - c1[i]^2)
+    end
+
+    # equivalent to: flatdutmp .= c*c1*c'dutmp[:] + c*c2*c'noise
+    copyto!(flatdutmp, dutmp)
+    mul!(tmp1, transpose(c), flatdutmp)
+    mul!(tmp2, c1, tmp1)
+    mul!(flatdutmp, c, tmp2)
+    
+    mul!(tmp1, transpose(c), noise)
+    mul!(tmp2, c2, tmp1)
+    mul!(tmp1, c, tmp2)
+
+    @.. flatdutmp += tmp1
+    copyto!(dutmp, flatdutmp)
+end
+
+function step_O!(friction::MDEFCache, integrator, v, r, t)
+    @unpack W, p, dt, sqdt = integrator
+    @unpack flatvtmp, tmp1, tmp2, gtmp, noise, c1, c2, sqrtmass, σ = friction
+
+    RingPolymerArrays.transform_from_normal_modes!(r, p.beads.transformation)
+    RingPolymerArrays.transform_from_normal_modes!(v, p.beads.transformation)
+
+    integrator.g(gtmp,r,p,t)
+    Λ = gtmp
+    @.. σ = sqrt(get_temperature(p, t)) * sqrtmass
+
+    @views for i in axes(r, 3)
+        @.. noise = σ * W.dW[:,:,i][:] / sqdt
+
+        γ, c = LAPACK.syev!('V', 'U', Λ[:,:,i]) # symmetric eigen
+        clamp!(γ, 0, Inf)
+        for (j,i) in enumerate(diagind(c1))
+            c1[i] = exp(-γ[j]*dt)
+            c2[i] = sqrt(1 - c1[i]^2)
+        end
+
+        copyto!(flatvtmp, v[:,:,i])
+        mul!(tmp1, transpose(c), flatvtmp)
+        mul!(tmp2, c1, tmp1)
+        mul!(flatvtmp, c, tmp2)
+        
+        mul!(tmp1, transpose(c), noise)
+        mul!(tmp2, c2, tmp1)
+        mul!(tmp1, c, tmp2)
+
+        @.. flatvtmp += tmp1
+        copyto!(v[:,:,i], flatvtmp)
+    end
+
+    RingPolymerArrays.transform_to_normal_modes!(r, p.beads.transformation)
+    RingPolymerArrays.transform_to_normal_modes!(v, p.beads.transformation)
+end
+
+function step_O!(friction::LangevinCache, integrator, v::RingPolymerArray, r::RingPolymerArray, t)
+    @unpack W, p, dt, sqdt = integrator
+    @unpack c1, c2, sqrtmass, σ = friction
+
+    @.. σ = sqrt(get_ring_polymer_temperature(p, t)) * sqrtmass
+
+    for i in axes(r, 3)
+        for j in RingPolymerArrays.quantumindices(v)
+            @. v[:,j,i] = c1[i] * v[:,j,i] + c2[i] * σ[:,j] * W.dW[:,j,i] / sqdt
+        end
+    end
+
+    for j in RingPolymerArrays.classicalindices(v)
+        @. v[:,j,1] = c1[1] * v[:,j,1] + c2[1] * σ[:,j] * W.dW[:,j,1] / sqdt
+    end
+end
+
+

--- a/test/Dynamics/algorithms/bcb.jl
+++ b/test/Dynamics/algorithms/bcb.jl
@@ -1,0 +1,44 @@
+
+using Test
+using NQCDynamics
+using Unitful, UnitfulAtomic
+using Distributions: Normal
+using OrdinaryDiffEq: DynamicalODEProblem, DynamicalODEFunction
+using DiffEqDevTools: DiffEqDevTools
+using RecursiveArrayTools: ArrayPartition
+
+atoms = Atoms(:H)
+model = Harmonic(m=atoms.masses[1])
+n_beads = 10
+sim = RingPolymerSimulation{Classical}(atoms, model, n_beads; temperature=300u"K")
+v = VelocityBoltzmann(n_beads*300u"K", atoms.masses, size(sim)[1:2])
+r = Normal(0.0, 0.01)
+d = DynamicalDistribution(v, r, size(sim))
+u0 = rand(d)
+
+function analytic(u0,p,t)
+    v0 = copy(DynamicsUtils.get_velocities(u0))
+    r0 = copy(DynamicsUtils.get_positions(u0))
+
+    RingPolymerArrays.transform_to_normal_modes!(v0, p.beads.transformation)
+    RingPolymerArrays.transform_to_normal_modes!(r0, p.beads.transformation)
+
+    ω = sqrt.(RingPolymers.get_matsubara_frequencies(n_beads, p.beads.ω_n).^2 .+ model.ω^2)
+    ω = reshape(ω, 1, 1, n_beads)
+    r = @. r0 * cos(ω*t) + v0 / ω * sin(ω.*t)
+    v = @. v0 * cos(ω*t) + -ω * r0 * sin(ω.*t)
+
+    RingPolymerArrays.transform_from_normal_modes!(v, p.beads.transformation)
+    RingPolymerArrays.transform_from_normal_modes!(r, p.beads.transformation)
+    return ArrayPartition(v, r)
+end
+
+tspan = (0.0, 10.0)
+func = DynamicalODEFunction(DynamicsMethods.ClassicalMethods.acceleration!, DynamicsUtils.velocity!; analytic)
+prob = DynamicalODEProblem(
+    func, Array(DynamicsUtils.get_velocities(u0)), Array(DynamicsUtils.get_positions(u0)), tspan, sim,
+)
+
+dts = (1/2) .^ (4:-1:-1)
+res = DiffEqDevTools.test_convergence(dts, prob, DynamicsMethods.IntegrationAlgorithms.BCB())
+@test res.𝒪est[:l∞] ≈ 2 atol=0.4

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -20,6 +20,7 @@ end
 if GROUP == "All" || GROUP == "Dynamics"
     @time @safetestset "DynamicsUtils Tests" begin include("Dynamics/DynamicsUtils.jl") end
     @time @safetestset "Classical Tests" begin include("Dynamics/classical.jl") end
+    @time @safetestset "BCB Tests" begin include("Dynamics/algorithms/bcb.jl") end
     @time @safetestset "Langevin Tests" begin include("Dynamics/langevin.jl") end
     @time @safetestset "MDEF BAOAB Tests" begin include("Dynamics/mdef_baoab.jl") end
     @time @safetestset "MDEF Tests" begin include("Dynamics/mdef.jl") end


### PR DESCRIPTION
- Previously adiabatic ring polymer dynamics defaulted to the VelocityVerlet algorithm. Now it will use the new BCB algorithm by default.
- All of the integration algorithms are declared at the top of the IntegrationAlgorithms module along with all the algorithm defaults.
- steps.jl contains a collection of some of the sub-steps used within a few different algorithms.