### PR TITLE
Update MDEF implementation for diabatic models

### DIFF
--- a/src/Calculators/Calculators.jl
+++ b/src/Calculators/Calculators.jl
@@ -19,7 +19,7 @@ using LinearAlgebra: LinearAlgebra, Hermitian, I, Eigen, tr
 using StaticArrays: SMatrix, SVector
 using RingPolymerArrays: get_centroid!
 
-using NQCModels: NQCModels, Model, nstates
+using NQCModels: NQCModels, Model, nstates, mobileatoms, dofs
 using NQCModels.AdiabaticModels: AdiabaticModel
 using NQCModels.DiabaticModels: DiabaticModel, DiabaticFrictionModel
 using NQCModels.FrictionModels: AdiabaticFrictionModel
@@ -46,6 +46,7 @@ NQCModels.nelectrons(calc::AbstractCalculator) = NQCModels.nelectrons(calc.model
 NQCModels.eachelectron(calc::AbstractCalculator) = NQCModels.eachelectron(calc.model)
 NQCModels.mobileatoms(calc::AbstractCalculator) = NQCModels.mobileatoms(calc.model, size(calc.derivative, 2))
 NQCModels.dofs(calc::AbstractCalculator) = NQCModels.dofs(calc.model)
+beads(calc) = Base.OneTo(length(calc.potential))
 
 Base.eltype(::AbstractCalculator{T}) where {T} = T
 
@@ -519,6 +520,7 @@ end
 
 include("friction.jl")
 include("large_diabatic.jl")
+include("ring_polymer_large_diabatic.jl")
 
 """
 Evaluates all electronic properties for the current position `r`.

--- a/src/Calculators/friction.jl
+++ b/src/Calculators/friction.jl
@@ -59,90 +59,9 @@ struct RingPolymerFrictionCalculator{T,M} <: AbstractFrictionCalculator{T,M}
     end
 end
 
-# struct DiabaticFrictionCalculator{T,M} <: AbstractDiabaticCalculator{T,M}
-#     model::M
-#     potential::DependentField{Hermitian{T,Matrix{T}},Matrix{T}}
-#     derivative::DependentField{Matrix{Hermitian{T,Matrix{T}}},Matrix{T}}
-#     eigen::DependentField{LinearAlgebra.Eigen{T,T,Matrix{T},Vector{T}},Matrix{T}}
-#     adiabatic_derivative::DependentField{Matrix{Matrix{T}},Matrix{T}}
-#     nonadiabatic_coupling::DependentField{Matrix{Matrix{T}},Matrix{T}}
-#     friction::DependentField{Matrix{T},Matrix{T}}
-#     tmp_mat::Matrix{T}
-
-#     function DiabaticFrictionCalculator{T}(model::M, atoms::Integer) where {T,M<:Model}
-#         mat = NQCModels.DiabaticModels.matrix_template(model, T)
-#         vec = NQCModels.DiabaticModels.vector_template(model, T)
-
-#         potential = Hermitian(zero(mat))
-#         derivative = [Hermitian(zero(mat)) for i=1:ndofs(model), j=1:atoms]
-#         eigen = Eigen(zero(vec), zero(mat)+I)
-#         adiabatic_derivative = [zero(mat) for i=1:ndofs(model), j=1:atoms]
-#         nonadiabatic_coupling = [zero(mat) for i=1:ndofs(model), j=1:atoms]
-#         friction = zeros(ndofs(model)*atoms, ndofs(model)*atoms)
-#         tmp_mat = zero(mat)
-
-#         position = fill(NaN, ndofs(model), atoms)
-
-#         new{T,M}(
-#             model,
-#             DependentField(potential, copy(position)),
-#             DependentField(derivative, copy(position)),
-#             DependentField(eigen, copy(position)),
-#             DependentField(adiabatic_derivative, copy(position)),
-#             DependentField(nonadiabatic_coupling, copy(position)),
-#             DependentField(friction, copy(position)),
-#             tmp_mat
-#         )
-#     end
-# end
-
-# struct RingPolymerDiabaticFrictionCalculator{T,M} <: AbstractDiabaticCalculator{T,M}
-#     model::M
-#     potential::DependentField{Vector{Hermitian{T,Matrix{T}}},Array{T,3}}
-#     derivative::DependentField{Array{Hermitian{T,Matrix{T}},3},Array{T,3}}
-#     eigen::DependentField{Vector{LinearAlgebra.Eigen{T,T,Matrix{T},Vector{T}}},Array{T,3}}
-#     adiabatic_derivative::DependentField{Array{Matrix{T},3},Array{T,3}}
-#     nonadiabatic_coupling::DependentField{Array{Matrix{T},3},Array{T,3}}
-#     friction::DependentField{Matrix{T},Array{T,3}}
-#     tmp_mat::Matrix{T}
-
-#     function RingPolymerDiabaticFrictionCalculator{T}(model::M, atoms::Integer, beads::Integer) where {T,M<:Model}
-#         n = nstates(model)
-#         matrix_template = NQCModels.DiabaticModels.matrix_template(model, T)
-#         vector_template = NQCModels.DiabaticModels.vector_template(model, T)
-
-#         potential = [Hermitian(matrix_template) for _=1:beads]
-#         derivative = [Hermitian(matrix_template) for _=1:ndofs(model), _=1:atoms, _=1:beads]
-#         adiabatic_derivative = [matrix_template for _=1:ndofs(model), _=1:atoms, _=1:beads]
-#         eigen = [Eigen(vector_template, matrix_template + I) for _=1:beads]
-#         nonadiabatic_coupling = [matrix_template for _=1:ndofs(model), _=1:atoms, _=1:beads]
-#         friction = zeros(ndofs(model)*atoms*beads, ndofs(model)*atoms*beads)
-#         tmp_mat = zeros(T, n, n)
-
-#         position = fill(NaN, ndofs(model), atoms, beads)
-
-#         new{T,M}(
-#             model,
-#             DependentField(potential, copy(position)),
-#             DependentField(derivative, copy(position)),
-#             DependentField(eigen, copy(position)),
-#             DependentField(adiabatic_derivative, copy(position)),
-#             DependentField(nonadiabatic_coupling, copy(position)),
-#             DependentField(friction, copy(position)),
-#             tmp_mat
-#         )
-#     end
-# end
-
 function Calculator(model::AdiabaticFrictionModel, atoms::Integer, t::Type{T}) where {T}
     FrictionCalculator{t}(model, atoms)
 end
-# function Calculator(model::DiabaticFrictionModel, atoms::Integer, t::Type{T}) where {T}
-#     DiabaticFrictionCalculator{t}(model, atoms)
-# end
-# function Calculator(model::DiabaticFrictionModel, atoms::Integer, beads::Integer, t::Type{T}) where {T}
-#     RingPolymerDiabaticFrictionCalculator{t}(model, atoms, beads)
-# end
 function Calculator(model::AdiabaticFrictionModel, atoms::Integer, beads::Integer, t::Type{T}) where {T}
     RingPolymerFrictionCalculator{t}(model, atoms, beads)
 end
@@ -158,48 +77,3 @@ function evaluate_friction!(calc::AbstractFrictionCalculator, R::AbstractArray{T
         NQCModels.friction!(calc.model, calc.friction[:,:,i], R[:,:,i])
     end
 end
-
-# @doc raw"""
-#     evaluate_friction!(calc::DiabaticFrictionCalculator, R::AbstractMatrix)
-
-# Evaluate the electronic friction for a model given in the diabatic representation.
-
-# ```math
-# γ = 2πħ ∑ᵢⱼ <i|dH|j><j|dH|i> (f(ϵᵢ)-f(ϵⱼ)) δ(ϵⱼ-ϵᵢ) / (ϵⱼ-ϵᵢ)
-# ```
-# Note that the delta function is approximated by a normalised gaussian.
-# """
-# function evaluate_friction!(calc::DiabaticFrictionCalculator, r::AbstractMatrix, β, σ, deriv=false)
-
-#     fermi(ϵ, μ, β) = 1 / (1 + exp(β*(ϵ-μ)))
-#     ∂fermi(ϵ, μ, β) = -β * exp(β*(ϵ-μ)) / (1 + exp(β*(ϵ-μ)))^2
-#     gauss(x, σ) = exp(-0.5 * x^2 / σ^2) / (σ*sqrt(2π))
-
-#     adiabatic_derivative = get_adiabatic_derivative(calc, r)
-#     eigen = get_eigen(calc, r)
-#     μ = NQCModels.fermilevel(calc.model)
-
-#     fill!(calc.friction, zero(eltype(calc)))
-#     for I in eachindex(r)
-#         for J in eachindex(r)
-#             for m=1:nstates(calc.model)
-#                 for n=m+1:nstates(calc.model)
-#                     ϵₙ = eigen.values[n]
-#                     ϵₘ = eigen.values[m]
-#                     Δϵ = ϵₙ - ϵₘ
-
-#                     fₙ = fermi(ϵₙ, μ, β)
-#                     fₘ = fermi(ϵₘ, μ, β)
-#                     Δf = (fₘ - fₙ)
-
-#                     coupling = adiabatic_derivative[I][n,m] * adiabatic_derivative[J][m,n]
-#                     if deriv
-#                         calc.friction[I,J] += -2π * coupling * gauss(Δϵ, σ) * ∂fermi(ϵₘ, μ, β)
-#                     else
-#                         calc.friction[I,J] += 2π * coupling * gauss(Δϵ, σ) * Δf / Δϵ
-#                     end
-#                 end
-#             end
-#         end
-#     end
-# end

--- a/src/Calculators/friction.jl
+++ b/src/Calculators/friction.jl
@@ -59,112 +59,90 @@ struct RingPolymerFrictionCalculator{T,M} <: AbstractFrictionCalculator{T,M}
     end
 end
 
-struct DiabaticFrictionCalculator{T,M} <: AbstractDiabaticCalculator{T,M}
-    model::M
-    potential::DependentField{Hermitian{T,Matrix{T}},Matrix{T}}
-    derivative::DependentField{Matrix{Hermitian{T,Matrix{T}}},Matrix{T}}
-    eigen::DependentField{LinearAlgebra.Eigen{T,T,Matrix{T},Vector{T}},Matrix{T}}
-    adiabatic_derivative::DependentField{Matrix{Matrix{T}},Matrix{T}}
-    nonadiabatic_coupling::DependentField{Matrix{Matrix{T}},Matrix{T}}
-    friction::DependentField{Matrix{T},Matrix{T}}
-    tmp_mat::Matrix{T}
-    stats::Dict{Symbol,Int}
+# struct DiabaticFrictionCalculator{T,M} <: AbstractDiabaticCalculator{T,M}
+#     model::M
+#     potential::DependentField{Hermitian{T,Matrix{T}},Matrix{T}}
+#     derivative::DependentField{Matrix{Hermitian{T,Matrix{T}}},Matrix{T}}
+#     eigen::DependentField{LinearAlgebra.Eigen{T,T,Matrix{T},Vector{T}},Matrix{T}}
+#     adiabatic_derivative::DependentField{Matrix{Matrix{T}},Matrix{T}}
+#     nonadiabatic_coupling::DependentField{Matrix{Matrix{T}},Matrix{T}}
+#     friction::DependentField{Matrix{T},Matrix{T}}
+#     tmp_mat::Matrix{T}
 
-    function DiabaticFrictionCalculator{T}(model::M, atoms::Integer) where {T,M<:Model}
-        mat = NQCModels.DiabaticModels.matrix_template(model, T)
-        vec = NQCModels.DiabaticModels.vector_template(model, T)
+#     function DiabaticFrictionCalculator{T}(model::M, atoms::Integer) where {T,M<:Model}
+#         mat = NQCModels.DiabaticModels.matrix_template(model, T)
+#         vec = NQCModels.DiabaticModels.vector_template(model, T)
 
-        potential = Hermitian(zero(mat))
-        derivative = [Hermitian(zero(mat)) for i=1:ndofs(model), j=1:atoms]
-        eigen = Eigen(zero(vec), zero(mat)+I)
-        adiabatic_derivative = [zero(mat) for i=1:ndofs(model), j=1:atoms]
-        nonadiabatic_coupling = [zero(mat) for i=1:ndofs(model), j=1:atoms]
-        friction = zeros(ndofs(model)*atoms, ndofs(model)*atoms)
-        tmp_mat = zero(mat)
+#         potential = Hermitian(zero(mat))
+#         derivative = [Hermitian(zero(mat)) for i=1:ndofs(model), j=1:atoms]
+#         eigen = Eigen(zero(vec), zero(mat)+I)
+#         adiabatic_derivative = [zero(mat) for i=1:ndofs(model), j=1:atoms]
+#         nonadiabatic_coupling = [zero(mat) for i=1:ndofs(model), j=1:atoms]
+#         friction = zeros(ndofs(model)*atoms, ndofs(model)*atoms)
+#         tmp_mat = zero(mat)
 
-        position = fill(NaN, ndofs(model), atoms)
+#         position = fill(NaN, ndofs(model), atoms)
 
-        stats = Dict{Symbol,Int}(
-            :potential=>0,
-            :derivative=>0,
-            :eigen=>0,
-            :adiabatic_derivative=>0,
-            :nonadiabatic_coupling=>0,
-            :friction=>0
-        )
+#         new{T,M}(
+#             model,
+#             DependentField(potential, copy(position)),
+#             DependentField(derivative, copy(position)),
+#             DependentField(eigen, copy(position)),
+#             DependentField(adiabatic_derivative, copy(position)),
+#             DependentField(nonadiabatic_coupling, copy(position)),
+#             DependentField(friction, copy(position)),
+#             tmp_mat
+#         )
+#     end
+# end
 
-        new{T,M}(
-            model,
-            DependentField(potential, copy(position)),
-            DependentField(derivative, copy(position)),
-            DependentField(eigen, copy(position)),
-            DependentField(adiabatic_derivative, copy(position)),
-            DependentField(nonadiabatic_coupling, copy(position)),
-            DependentField(friction, copy(position)),
-            tmp_mat,
-            stats
-        )
-    end
-end
+# struct RingPolymerDiabaticFrictionCalculator{T,M} <: AbstractDiabaticCalculator{T,M}
+#     model::M
+#     potential::DependentField{Vector{Hermitian{T,Matrix{T}}},Array{T,3}}
+#     derivative::DependentField{Array{Hermitian{T,Matrix{T}},3},Array{T,3}}
+#     eigen::DependentField{Vector{LinearAlgebra.Eigen{T,T,Matrix{T},Vector{T}}},Array{T,3}}
+#     adiabatic_derivative::DependentField{Array{Matrix{T},3},Array{T,3}}
+#     nonadiabatic_coupling::DependentField{Array{Matrix{T},3},Array{T,3}}
+#     friction::DependentField{Matrix{T},Array{T,3}}
+#     tmp_mat::Matrix{T}
 
-struct RingPolymerDiabaticFrictionCalculator{T,M} <: AbstractDiabaticCalculator{T,M}
-    model::M
-    potential::DependentField{Vector{Hermitian{T,Matrix{T}}},Array{T,3}}
-    derivative::DependentField{Array{Hermitian{T,Matrix{T}},3},Array{T,3}}
-    eigen::DependentField{Vector{LinearAlgebra.Eigen{T,T,Matrix{T},Vector{T}}},Array{T,3}}
-    adiabatic_derivative::DependentField{Array{Matrix{T},3},Array{T,3}}
-    nonadiabatic_coupling::DependentField{Array{Matrix{T},3},Array{T,3}}
-    friction::DependentField{Matrix{T},Array{T,3}}
-    tmp_mat::Matrix{T}
-    stats::Dict{Symbol,Int}
+#     function RingPolymerDiabaticFrictionCalculator{T}(model::M, atoms::Integer, beads::Integer) where {T,M<:Model}
+#         n = nstates(model)
+#         matrix_template = NQCModels.DiabaticModels.matrix_template(model, T)
+#         vector_template = NQCModels.DiabaticModels.vector_template(model, T)
 
-    function RingPolymerDiabaticFrictionCalculator{T}(model::M, atoms::Integer, beads::Integer) where {T,M<:Model}
-        n = nstates(model)
-        matrix_template = NQCModels.DiabaticModels.matrix_template(model, T)
-        vector_template = NQCModels.DiabaticModels.vector_template(model, T)
+#         potential = [Hermitian(matrix_template) for _=1:beads]
+#         derivative = [Hermitian(matrix_template) for _=1:ndofs(model), _=1:atoms, _=1:beads]
+#         adiabatic_derivative = [matrix_template for _=1:ndofs(model), _=1:atoms, _=1:beads]
+#         eigen = [Eigen(vector_template, matrix_template + I) for _=1:beads]
+#         nonadiabatic_coupling = [matrix_template for _=1:ndofs(model), _=1:atoms, _=1:beads]
+#         friction = zeros(ndofs(model)*atoms*beads, ndofs(model)*atoms*beads)
+#         tmp_mat = zeros(T, n, n)
 
-        potential = [Hermitian(matrix_template) for _=1:beads]
-        derivative = [Hermitian(matrix_template) for _=1:ndofs(model), _=1:atoms, _=1:beads]
-        adiabatic_derivative = [matrix_template for _=1:ndofs(model), _=1:atoms, _=1:beads]
-        eigen = [Eigen(vector_template, matrix_template + I) for _=1:beads]
-        nonadiabatic_coupling = [matrix_template for _=1:ndofs(model), _=1:atoms, _=1:beads]
-        friction = zeros(ndofs(model)*atoms*beads, ndofs(model)*atoms*beads)
-        tmp_mat = zeros(T, n, n)
+#         position = fill(NaN, ndofs(model), atoms, beads)
 
-        position = fill(NaN, ndofs(model), atoms, beads)
-
-        stats = Dict{Symbol,Int}(
-            :potential=>0,
-            :derivative=>0,
-            :eigen=>0,
-            :adiabatic_derivative=>0,
-            :nonadiabatic_coupling=>0,
-            :friction=>0
-        )
-
-        new{T,M}(
-            model,
-            DependentField(potential, copy(position)),
-            DependentField(derivative, copy(position)),
-            DependentField(eigen, copy(position)),
-            DependentField(adiabatic_derivative, copy(position)),
-            DependentField(nonadiabatic_coupling, copy(position)),
-            DependentField(friction, copy(position)),
-            tmp_mat,
-            stats
-        )
-    end
-end
+#         new{T,M}(
+#             model,
+#             DependentField(potential, copy(position)),
+#             DependentField(derivative, copy(position)),
+#             DependentField(eigen, copy(position)),
+#             DependentField(adiabatic_derivative, copy(position)),
+#             DependentField(nonadiabatic_coupling, copy(position)),
+#             DependentField(friction, copy(position)),
+#             tmp_mat
+#         )
+#     end
+# end
 
 function Calculator(model::AdiabaticFrictionModel, atoms::Integer, t::Type{T}) where {T}
     FrictionCalculator{t}(model, atoms)
 end
-function Calculator(model::DiabaticFrictionModel, atoms::Integer, t::Type{T}) where {T}
-    DiabaticFrictionCalculator{t}(model, atoms)
-end
-function Calculator(model::DiabaticFrictionModel, atoms::Integer, beads::Integer, t::Type{T}) where {T}
-    RingPolymerDiabaticFrictionCalculator{t}(model, atoms, beads)
-end
+# function Calculator(model::DiabaticFrictionModel, atoms::Integer, t::Type{T}) where {T}
+#     DiabaticFrictionCalculator{t}(model, atoms)
+# end
+# function Calculator(model::DiabaticFrictionModel, atoms::Integer, beads::Integer, t::Type{T}) where {T}
+#     RingPolymerDiabaticFrictionCalculator{t}(model, atoms, beads)
+# end
 function Calculator(model::AdiabaticFrictionModel, atoms::Integer, beads::Integer, t::Type{T}) where {T}
     RingPolymerFrictionCalculator{t}(model, atoms, beads)
 end
@@ -181,31 +159,47 @@ function evaluate_friction!(calc::AbstractFrictionCalculator, R::AbstractArray{T
     end
 end
 
-@doc raw"""
-    evaluate_friction!(calc::DiabaticFrictionCalculator, R::AbstractMatrix)
+# @doc raw"""
+#     evaluate_friction!(calc::DiabaticFrictionCalculator, R::AbstractMatrix)
 
-Evaluate the electronic friction for a model given in the diabatic representation.
+# Evaluate the electronic friction for a model given in the diabatic representation.
 
-```math
-γ = 2πħ ∑ⱼ <1|dH|j><j|dH|1> δ(ωⱼ) / ωⱼ
-```
-Note that the delta function is approximated by a normalised gaussian.
-"""
-function evaluate_friction!(calc::DiabaticFrictionCalculator, r::AbstractMatrix)
+# ```math
+# γ = 2πħ ∑ᵢⱼ <i|dH|j><j|dH|i> (f(ϵᵢ)-f(ϵⱼ)) δ(ϵⱼ-ϵᵢ) / (ϵⱼ-ϵᵢ)
+# ```
+# Note that the delta function is approximated by a normalised gaussian.
+# """
+# function evaluate_friction!(calc::DiabaticFrictionCalculator, r::AbstractMatrix, β, σ, deriv=false)
 
-    gauss(x, σ) = exp(-0.5 * x^2 / σ^2) / (σ*sqrt(2π))
-    adiabatic_derivative = get_adiabatic_derivative(calc, r)
-    eigen = get_eigen(calc, r)
+#     fermi(ϵ, μ, β) = 1 / (1 + exp(β*(ϵ-μ)))
+#     ∂fermi(ϵ, μ, β) = -β * exp(β*(ϵ-μ)) / (1 + exp(β*(ϵ-μ)))^2
+#     gauss(x, σ) = exp(-0.5 * x^2 / σ^2) / (σ*sqrt(2π))
 
-    dofs = ndofs(calc.model)
-    calc.friction .= 0
-    for i in axes(r, 2) # Atoms
-        for j in axes(r, 1) # dofs
-            for m=2:nstates(calc.model)
-                ω = eigen.values[m] - eigen.values[1]
-                g = gauss(ω, calc.model.σ) / ω
-                calc.friction[j+(i-1)*dofs] += 2π*abs2(adiabatic_derivative[j,i][m,1])*g
-            end
-        end
-    end
-end
+#     adiabatic_derivative = get_adiabatic_derivative(calc, r)
+#     eigen = get_eigen(calc, r)
+#     μ = NQCModels.fermilevel(calc.model)
+
+#     fill!(calc.friction, zero(eltype(calc)))
+#     for I in eachindex(r)
+#         for J in eachindex(r)
+#             for m=1:nstates(calc.model)
+#                 for n=m+1:nstates(calc.model)
+#                     ϵₙ = eigen.values[n]
+#                     ϵₘ = eigen.values[m]
+#                     Δϵ = ϵₙ - ϵₘ
+
+#                     fₙ = fermi(ϵₙ, μ, β)
+#                     fₘ = fermi(ϵₘ, μ, β)
+#                     Δf = (fₘ - fₙ)
+
+#                     coupling = adiabatic_derivative[I][n,m] * adiabatic_derivative[J][m,n]
+#                     if deriv
+#                         calc.friction[I,J] += -2π * coupling * gauss(Δϵ, σ) * ∂fermi(ϵₘ, μ, β)
+#                     else
+#                         calc.friction[I,J] += 2π * coupling * gauss(Δϵ, σ) * Δf / Δϵ
+#                     end
+#                 end
+#             end
+#         end
+#     end
+# end

--- a/src/Calculators/large_diabatic.jl
+++ b/src/Calculators/large_diabatic.jl
@@ -48,13 +48,13 @@ function Calculator(model::LargeDiabaticModel, atoms::Integer, T::Type=Float64)
     LargeDiabaticCalculator{T}(model, atoms)
 end
 
-function evaluate_potential!(calc::Union{LargeDiabaticCalculator,DiabaticFrictionCalculator}, r)
+function evaluate_potential!(calc::LargeDiabaticCalculator, r)
     calc.stats[:potential] += 1
     NQCModels.potential!(calc.model, calc.potential, r)
     return nothing
 end
 
-function evaluate_eigen!(calc::Union{LargeDiabaticCalculator,DiabaticFrictionCalculator}, r)
+function evaluate_eigen!(calc::LargeDiabaticCalculator, r)
     calc.stats[:eigen] += 1
     potential = get_potential(calc, r)
     eig = LinearAlgebra.eigen(potential)
@@ -71,7 +71,7 @@ function correct_phase!(eig::LinearAlgebra.Eigen, old_eigenvectors::AbstractMatr
     end
 end
 
-function evaluate_adiabatic_derivative!(calc::Union{LargeDiabaticCalculator,DiabaticFrictionCalculator}, r)
+function evaluate_adiabatic_derivative!(calc::LargeDiabaticCalculator, r)
     calc.stats[:adiabatic_derivative] += 1
     eigen = get_eigen(calc, r)
     derivative = get_derivative(calc, r)
@@ -83,7 +83,7 @@ function evaluate_adiabatic_derivative!(calc::Union{LargeDiabaticCalculator,Diab
     end
 end
 
-function evaluate_nonadiabatic_coupling!(calc::Union{LargeDiabaticCalculator,DiabaticFrictionCalculator}, r)
+function evaluate_nonadiabatic_coupling!(calc::LargeDiabaticCalculator, r)
     calc.stats[:nonadiabatic_coupling] += 1
     eigen = get_eigen(calc, r)
     adiabatic_derivative = get_adiabatic_derivative(calc, r)

--- a/src/Calculators/large_diabatic.jl
+++ b/src/Calculators/large_diabatic.jl
@@ -1,7 +1,9 @@
 
 using NQCModels.DiabaticModels: LargeDiabaticModel
 
-struct LargeDiabaticCalculator{T,M} <: AbstractDiabaticCalculator{T,M}
+abstract type AbstractLargeDiabaticCalculators{T,M} <: AbstractDiabaticCalculator{T,M} end
+
+struct LargeDiabaticCalculator{T,M} <: AbstractLargeDiabaticCalculators{T,M}
     model::M
     potential::DependentField{Hermitian{T,Matrix{T}},Matrix{T}}
     derivative::DependentField{Matrix{Hermitian{T,Matrix{T}}},Matrix{T}}

--- a/src/Calculators/ring_polymer_large_diabatic.jl
+++ b/src/Calculators/ring_polymer_large_diabatic.jl
@@ -1,0 +1,94 @@
+
+struct RingPolymerLargeDiabaticCalculator{T,M} <: AbstractLargeDiabaticCalculators{T,M}
+    model::M
+    potential::DependentField{Vector{Hermitian{T,Matrix{T}}},Array{T,3}}
+    derivative::DependentField{Array{Hermitian{T,Matrix{T}},3},Array{T,3}}
+    eigen::DependentField{Vector{LinearAlgebra.Eigen{T,T,Matrix{T},Vector{T}}},Array{T,3}}
+    adiabatic_derivative::DependentField{Array{Matrix{T},3},Array{T,3}}
+    nonadiabatic_coupling::DependentField{Array{Matrix{T},3},Array{T,3}}
+    tmp_mat::Matrix{T}
+    stats::Dict{Symbol,Int}
+    function RingPolymerLargeDiabaticCalculator{T}(model::M, atoms::Integer, beads::Integer) where {T,M<:Model}
+        mat = NQCModels.DiabaticModels.matrix_template(model, T)
+        vec = NQCModels.DiabaticModels.vector_template(model, T)
+
+        potential = [Hermitian(zero(mat)) for _=1:beads]
+        derivative = [Hermitian(zero(mat)) for _=1:ndofs(model), _=1:atoms, _=1:beads]
+        eigen = [Eigen(zero(vec), zero(mat)+I) for _=1:beads]
+        adiabatic_derivative = [zero(mat) for _=1:ndofs(model), _=1:atoms, _=1:beads]
+        nonadiabatic_coupling = [zero(mat) for _=1:ndofs(model), _=1:atoms, _=1:beads]
+        tmp_mat = zero(mat)
+
+        position = fill(NaN, ndofs(model), atoms, beads)
+
+        stats = Dict{Symbol,Int}(
+            :potential=>0,
+            :derivative=>0,
+            :eigen=>0,
+            :adiabatic_derivative=>0,
+            :nonadiabatic_coupling=>0
+        )
+
+        new{T,M}(
+            model,
+            DependentField(potential, copy(position)),
+            DependentField(derivative, copy(position)),
+            DependentField(eigen, copy(position)),
+            DependentField(adiabatic_derivative, copy(position)),
+            DependentField(nonadiabatic_coupling, copy(position)),
+            tmp_mat,
+            stats,
+        )
+    end
+end
+
+function Calculator(model::LargeDiabaticModel, atoms::Integer, beads::Integer, T::Type=Float64)
+    RingPolymerLargeDiabaticCalculator{T}(model, atoms, beads)
+end
+
+function evaluate_potential!(calc::RingPolymerLargeDiabaticCalculator, r::AbstractArray{T,3}) where {T}
+    calc.stats[:potential] += 1
+    @views @inbounds for i in beads(calc)
+        NQCModels.potential!(calc.model, calc.potential[i], r[:,:,i])
+    end
+end
+
+function evaluate_eigen!(calc::RingPolymerLargeDiabaticCalculator, r::AbstractArray{T,3}) where {T}
+    calc.stats[:eigen] += 1
+    potential = get_potential(calc, r)
+    @inbounds for i in beads(calc)
+        eig = LinearAlgebra.eigen(potential[i])
+        correct_phase!(eig, calc.eigen[i].vectors)
+        copy!(calc.eigen[i].vectors, eig.vectors)
+        copy!(calc.eigen[i].values, eig.values)
+    end
+end
+
+function evaluate_adiabatic_derivative!(calc::RingPolymerLargeDiabaticCalculator, r::AbstractArray{T,3}) where {T}
+    calc.stats[:adiabatic_derivative] += 1
+    eigen = get_eigen(calc, r)
+    derivative = get_derivative(calc, r)
+    @inbounds for i in beads(calc)
+        for j in mobileatoms(calc)
+            for k in dofs(calc)
+                LinearAlgebra.mul!(calc.tmp_mat, derivative[k,j,i], eigen[i].vectors)
+                LinearAlgebra.mul!(calc.adiabatic_derivative[k,j,i], eigen[i].vectors', calc.tmp_mat)
+            end
+        end
+    end
+end
+
+function evaluate_nonadiabatic_coupling!(calc::RingPolymerLargeDiabaticCalculator, r::AbstractArray{T,3}) where {T}
+    calc.stats[:nonadiabatic_coupling] += 1
+    eigen = get_eigen(calc, r)
+    adiabatic_derivative = get_adiabatic_derivative(calc, r)
+
+    @inbounds for i in beads(calc)
+        evaluate_inverse_difference_matrix!(calc.tmp_mat, eigen[i].values)
+        for j in mobileatoms(calc)
+            for k in dofs(calc)
+                multiply_elementwise!(calc.nonadiabatic_coupling[k,j,i], adiabatic_derivative[k,j,i], calc.tmp_mat)
+            end
+        end
+    end
+end

--- a/src/DynamicsMethods/ClassicalMethods/ClassicalMethods.jl
+++ b/src/DynamicsMethods/ClassicalMethods/ClassicalMethods.jl
@@ -20,8 +20,10 @@ include("langevin.jl")
 export Langevin, ThermalLangevin
 include("mdef.jl")
 export MDEF
+include("diabatic_mdef.jl")
+export DiabaticMDEF
 
-const ClassicalMethodUnion = Union{Classical, Langevin, ThermalLangevin, MDEF}
+const ClassicalMethodUnion = Union{Classical, Langevin, ThermalLangevin, MDEF, DiabaticMDEF}
 
 function DynamicsUtils.classical_hamiltonian(sim::AbstractSimulation{<:ClassicalMethodUnion}, u)
     kinetic = DynamicsUtils.classical_kinetic_energy(sim, DynamicsUtils.get_velocities(u))

--- a/src/DynamicsMethods/ClassicalMethods/ClassicalMethods.jl
+++ b/src/DynamicsMethods/ClassicalMethods/ClassicalMethods.jl
@@ -22,6 +22,7 @@ include("mdef.jl")
 export MDEF
 include("diabatic_mdef.jl")
 export DiabaticMDEF
+include("rpmdef.jl")
 
 const ClassicalMethodUnion = Union{Classical, Langevin, ThermalLangevin, MDEF, DiabaticMDEF}
 

--- a/src/DynamicsMethods/ClassicalMethods/diabatic_mdef.jl
+++ b/src/DynamicsMethods/ClassicalMethods/diabatic_mdef.jl
@@ -1,0 +1,107 @@
+using NQCModels: NQCModels
+using NQCDynamics: get_temperature
+
+struct DiabaticMDEF{T,M} <: AbstractMDEF
+    mass_scaling::M
+    fermi_level::T
+    σ::T
+    friction_type::Symbol
+end
+
+function DiabaticMDEF(masses::AbstractVector, DoFs::Integer, fermi_level, σ, friction_type)
+    DiabaticMDEF(get_mass_scale_matrix(masses, DoFs), austrip(fermi_level), austrip(σ), friction_type)
+end
+
+function NQCDynamics.Simulation{DiabaticMDEF}(atoms::Atoms, model::Model;
+    fermi_level=0.0, σ=1.0, friction_type=:GB,
+    kwargs...
+)
+    NQCDynamics.Simulation(atoms, model,
+        DiabaticMDEF(atoms.masses, ndofs(model), fermi_level, σ, friction_type);
+        kwargs...
+    )
+end
+
+function acceleration!(dv, v, r, sim::Simulation{<:DiabaticMDEF}, t)
+
+    adiabatic_derivative = Calculators.get_adiabatic_derivative(sim.calculator, r)
+    eigen = Calculators.get_eigen(sim.calculator, r)
+
+    NQCModels.state_independent_derivative!(sim.calculator.model, dv, r)
+    LinearAlgebra.lmul!(-1, dv)
+    for I in eachindex(dv)
+        for i in eachindex(eigen.values)
+            f = fermi(eigen.values[i], sim.method.fermi_level, 1/get_temperature(sim, t))
+            dv[I] -= adiabatic_derivative[I][i,i] * f
+        end
+    end
+    DynamicsUtils.divide_by_mass!(dv, sim.atoms.masse)
+
+    return nothing
+end
+
+function friction!(g, r, sim::Simulation{<:DiabaticMDEF}, t)
+    # Calculators.evaluate_friction!(sim.calculator, r)
+    # g .= sim.calculator.friction ./ sim.method.mass_scaling
+end
+
+fermi(ϵ, μ, β) = 1 / (1 + exp(β*(ϵ-μ)))
+∂fermi(ϵ, μ, β) = -β * exp(β*(ϵ-μ)) / (1 + exp(β*(ϵ-μ)))^2
+gauss(x, σ) = exp(-0.5 * x^2 / σ^2) / (σ*sqrt(2π))
+
+function evaluate_friction!(Λ::AbstractMatrix, sim::Simulation{<:DiabaticMDEF}, r::AbstractMatrix, t::Real)
+    ∂H = Calculators.get_adiabatic_derivative(sim.calculator, r)
+    eigen = Calculators.get_eigen(sim.calculator, r)
+    μ = NQCModels.fermilevel(sim.calculator.model)
+    σ = sim.method.σ
+    β = 1/get_temperature(sim, t)
+
+    fill!(Λ, zero(eltype(r)))
+    for I in eachindex(r)
+        for J in eachindex(r)
+            if sim.method.friction_type === :GB
+                Λ[I,J] = friction_gaussian_broadening(∂H[I], ∂H[J], eigen.values, μ, β, σ)
+            elseif sim.method.friction_type === :ONGB
+                Λ[I,J] = friction_off_diagonal_gaussian_broadening(∂H[I], ∂H[J], eigen.values, μ, β, σ)
+            else
+                throw(ArgumentError("Friction type $(sim.method.friction_type) not recognised."))
+            end
+        end
+    end
+end
+
+function friction_gaussian_broadening(∂Hᵢ, ∂Hⱼ, eigenvalues, μ, β, σ)
+    out = zero(eltype(eigenvalues))
+    for n in eachindex(eigenvalues)
+        for m in eachindex(eigenvalues)
+            # if n != m
+                ϵₙ = eigenvalues[n]
+                ϵₘ = eigenvalues[m]
+                Δϵ = ϵₙ - ϵₘ
+                out += -π * ∂Hᵢ[n,m] * ∂Hⱼ[m,n] * gauss(Δϵ, σ) * ∂fermi(ϵₙ, μ, β)
+            # end
+        end
+    end
+    return out
+end
+
+function friction_off_diagonal_gaussian_broadening(∂Hᵢ, ∂Hⱼ, eigenvalues, μ, β, σ)
+    out = zero(eltype(eigenvalues))
+    for n in eachindex(eigenvalues)
+        # for m in eachindex(eigenvalues)
+        for m=n+1:length(eigenvalues)
+            if n != m
+                ϵₙ = eigenvalues[n]
+                ϵₘ = eigenvalues[m]
+                Δϵ = ϵₙ - ϵₘ
+
+                fₙ = fermi(ϵₙ, μ, β)
+                fₘ = fermi(ϵₘ, μ, β)
+                Δf = (fₘ - fₙ)
+
+                out += 2π * ∂Hᵢ[n,m] * ∂Hⱼ[m,n] * gauss(Δϵ, σ) * Δf / Δϵ
+            end
+        end
+    end
+    return out
+end

--- a/src/DynamicsMethods/ClassicalMethods/diabatic_mdef.jl
+++ b/src/DynamicsMethods/ClassicalMethods/diabatic_mdef.jl
@@ -24,7 +24,7 @@ function NQCDynamics.Simulation{DiabaticMDEF}(atoms::Atoms, model::Model;
     )
 end
 
-function acceleration!(dv, v, r, sim::Simulation{<:DiabaticMDEF}, t)
+function acceleration!(dv, v, r, sim::Simulation{<:Union{DiabaticMDEF,Classical},<:Calculators.LargeDiabaticCalculator}, t)
 
     adiabatic_derivative = Calculators.get_adiabatic_derivative(sim.calculator, r)
     eigen = Calculators.get_eigen(sim.calculator, r)
@@ -178,7 +178,10 @@ function determine_fermi_level(nelectrons, β, eigenvalues)
     return μ
 end
 
-function DynamicsUtils.classical_potential_energy(sim::Simulation{<:DiabaticMDEF}, r::AbstractMatrix)
+function DynamicsUtils.classical_potential_energy(
+    sim::Simulation{<:Union{DiabaticMDEF,Classical},<:Calculators.LargeDiabaticCalculator},
+    r::AbstractMatrix
+)
     eigen = Calculators.get_eigen(sim.calculator, r)
     μ = NQCModels.fermilevel(sim.calculator.model)
     β = 1 / get_temperature(sim)

--- a/src/DynamicsMethods/ClassicalMethods/mdef.jl
+++ b/src/DynamicsMethods/ClassicalMethods/mdef.jl
@@ -1,5 +1,5 @@
 
-using NQCDynamics.Calculators: DiabaticFrictionCalculator
+# using NQCDynamics.Calculators: DiabaticFrictionCalculator
 
 abstract type AbstractMDEF <: DynamicsMethods.Method end
 
@@ -33,18 +33,18 @@ function NQCDynamics.RingPolymerSimulation{MDEF}(atoms::Atoms, model::Model, n_b
     NQCDynamics.RingPolymerSimulation(atoms, model, MDEF(atoms.masses, ndofs(model)), n_beads; kwargs...)
 end
 
-"""
-    acceleration!(dv, v, r, sim::Simulation{MDEF,<:DiabaticFrictionCalculator}, t)
+# """
+#     acceleration!(dv, v, r, sim::Simulation{MDEF,<:DiabaticFrictionCalculator}, t)
 
-Sets acceleration due to ground state force when using a `DiabaticFrictionModel`.
-"""
-function acceleration!(dv, v, r, sim::Simulation{MDEF,<:DiabaticFrictionCalculator}, t)
-    Calculators.update_electronics!(sim.calculator, r)
-    for I in eachindex(dv)
-        dv[I] = -sim.calculator.adiabatic_derivative[I][1,1]
-    end
-    DynamicsUtils.divide_by_mass!(dv, sim.atoms.masse)
-end
+# Sets acceleration due to ground state force when using a `DiabaticFrictionModel`.
+# """
+# function acceleration!(dv, v, r, sim::Simulation{MDEF,<:DiabaticFrictionCalculator}, t)
+#     Calculators.update_electronics!(sim.calculator, r)
+#     for I in eachindex(dv)
+#         dv[I] = -sim.calculator.adiabatic_derivative[I][1,1]
+#     end
+#     DynamicsUtils.divide_by_mass!(dv, sim.atoms.masse)
+# end
 
 """
     friction!(g, r, sim, t)

--- a/src/DynamicsMethods/ClassicalMethods/mdef.jl
+++ b/src/DynamicsMethods/ClassicalMethods/mdef.jl
@@ -37,8 +37,8 @@ end
 Evaluates friction tensor
 """
 function friction!(g, r, sim::AbstractSimulation{<:AbstractMDEF}, t)
-    Calculators.evaluate_friction!(sim.calculator, r)
-    g .= sim.calculator.friction ./ sim.method.mass_scaling
+    friction = Calculators.get_friction(sim.calculator, r)
+    g .= friction ./ sim.method.mass_scaling
 end
 
 function DynamicsMethods.create_problem(u0, tspan::Tuple, sim::AbstractSimulation{<:AbstractMDEF})

--- a/src/DynamicsMethods/ClassicalMethods/mdef.jl
+++ b/src/DynamicsMethods/ClassicalMethods/mdef.jl
@@ -1,6 +1,4 @@
 
-# using NQCDynamics.Calculators: DiabaticFrictionCalculator
-
 abstract type AbstractMDEF <: DynamicsMethods.Method end
 
 """
@@ -32,19 +30,6 @@ end
 function NQCDynamics.RingPolymerSimulation{MDEF}(atoms::Atoms, model::Model, n_beads::Integer; kwargs...)
     NQCDynamics.RingPolymerSimulation(atoms, model, MDEF(atoms.masses, ndofs(model)), n_beads; kwargs...)
 end
-
-# """
-#     acceleration!(dv, v, r, sim::Simulation{MDEF,<:DiabaticFrictionCalculator}, t)
-
-# Sets acceleration due to ground state force when using a `DiabaticFrictionModel`.
-# """
-# function acceleration!(dv, v, r, sim::Simulation{MDEF,<:DiabaticFrictionCalculator}, t)
-#     Calculators.update_electronics!(sim.calculator, r)
-#     for I in eachindex(dv)
-#         dv[I] = -sim.calculator.adiabatic_derivative[I][1,1]
-#     end
-#     DynamicsUtils.divide_by_mass!(dv, sim.atoms.masse)
-# end
 
 """
     friction!(g, r, sim, t)

--- a/src/DynamicsMethods/ClassicalMethods/rpmdef.jl
+++ b/src/DynamicsMethods/ClassicalMethods/rpmdef.jl
@@ -11,7 +11,7 @@ function NQCDynamics.RingPolymerSimulation{DiabaticMDEF}(atoms::Atoms, model::Mo
     )
 end
 
-function acceleration!(dv, v, r, sim::RingPolymerSimulation{<:DiabaticMDEF}, t)
+function acceleration!(dv, v, r, sim::RingPolymerSimulation{<:Union{DiabaticMDEF,Classical},<:Calculators.RingPolymerLargeDiabaticCalculator}, t)
 
     adiabatic_derivative = Calculators.get_adiabatic_derivative(sim.calculator, r)
     eigen = Calculators.get_eigen(sim.calculator, r)
@@ -53,7 +53,10 @@ function evaluate_friction!(Λ::AbstractArray{T,3}, sim::RingPolymerSimulation{<
     return Λ
 end
 
-function DynamicsUtils.classical_potential_energy(sim::RingPolymerSimulation{<:DiabaticMDEF}, r::AbstractArray{T,3}) where {T}
+function DynamicsUtils.classical_potential_energy(
+    sim::RingPolymerSimulation{<:Union{Classical,DiabaticMDEF},<:Calculators.RingPolymerLargeDiabaticCalculator},
+    r::AbstractArray{T,3}
+) where {T}
     eigen = Calculators.get_eigen(sim.calculator, r)
     μ = NQCModels.fermilevel(sim.calculator.model)
     β = 1 / get_temperature(sim)

--- a/src/DynamicsMethods/ClassicalMethods/rpmdef.jl
+++ b/src/DynamicsMethods/ClassicalMethods/rpmdef.jl
@@ -1,0 +1,52 @@
+
+function NQCDynamics.RingPolymerSimulation{DiabaticMDEF}(atoms::Atoms, model::Model, n_beads::Integer;
+    friction_method, kwargs...
+)
+    NQCDynamics.RingPolymerSimulation(atoms, model,
+        DiabaticMDEF(atoms.masses, ndofs(model), friction_method),
+        n_beads;
+        kwargs...
+    )
+end
+
+function acceleration!(dv, v, r, sim::RingPolymerSimulation{<:DiabaticMDEF}, t)
+
+    adiabatic_derivative = Calculators.get_adiabatic_derivative(sim.calculator, r)
+    eigen = Calculators.get_eigen(sim.calculator, r)
+    μ = NQCModels.fermilevel(sim.calculator.model)
+    β = 1 / get_temperature(sim, t)
+
+    @views for i in Calculators.beads(sim.calculator)
+        NQCModels.state_independent_derivative!(sim.calculator.model, dv[:,:,i], r[:,:,i])
+        current_bead_eigen = eigen[i]
+        for j in NQCModels.mobileatoms(sim)
+            for k in NQCModels.dofs(sim)
+                for n in NQCModels.eachstate(sim)
+                    f = fermi(current_bead_eigen.values[n], μ, β)
+                    dv[k,j,i] += adiabatic_derivative[k,j,i][n,n] * f
+                end
+            end
+        end
+    end
+    LinearAlgebra.lmul!(-1, dv)
+    DynamicsUtils.divide_by_mass!(dv, masses(sim))
+
+    return nothing
+end
+
+function evaluate_friction!(Λ::AbstractArray{T,3}, sim::RingPolymerSimulation{<:DiabaticMDEF}, r::AbstractArray{T,3}, t::Real) where {T}
+    β = 1 / get_temperature(sim, t)
+    μ = NQCModels.fermilevel(sim.calculator.model)
+    @views for i in Calculators.beads(sim.calculator)
+        if sim.method.friction_method isa WideBandExact
+            potential = Calculators.get_potential(sim.calculator, r)
+            derivative = Calculators.get_derivative(sim.calculator, r)
+            fill_friction_tensor!(Λ[:,:,i], sim.method.friction_method, potential[i], derivative[:,:,i], r[:,:,i], μ, β)
+        else
+            ∂H = Calculators.get_adiabatic_derivative(sim.calculator, r)
+            eigen = Calculators.get_eigen(sim.calculator, r)
+            fill_friction_tensor!(Λ[:,:,i], sim.method.friction_method, ∂H[:,:,i], eigen[i], r[:,:,i], μ, β)
+        end
+    end
+    return Λ
+end

--- a/src/DynamicsMethods/DynamicsMethods.jl
+++ b/src/DynamicsMethods/DynamicsMethods.jl
@@ -112,7 +112,7 @@ function run_trajectory(u0, tspan::Tuple, sim::AbstractSimulation;
     @info "Performing a single trajectory."
     stats = @timed DiffEqBase.solve(problem, algorithm; stripped_kwargs...)
     @info "Finished after $(stats.time) seconds."
-    @debug "Integration algorithm: $(stats.value.alg)"
+    @debug "Simulation details" algorithm=stats.value.alg defunction=problem.f
     out = [(;zip(output, val)...) for val in vals.saveval]
     TypedTables.Table(t=vals.t, out)
 end

--- a/src/DynamicsMethods/IntegrationAlgorithms/bcocb.jl
+++ b/src/DynamicsMethods/IntegrationAlgorithms/bcocb.jl
@@ -43,7 +43,7 @@ struct MDEFCache{flatV,G,N,C,M,S}
     σ::S
 end
 
-function FrictionCache(sim::RingPolymerSimulation{<:DynamicsMethods.ClassicalMethods.MDEF}, dt) 
+function FrictionCache(sim::RingPolymerSimulation{<:DynamicsMethods.ClassicalMethods.AbstractMDEF}, dt) 
     DoFs = ndofs(sim)
     atoms = length(sim.atoms)
     beads = length(sim.beads)

--- a/src/DynamicsMethods/IntegrationAlgorithms/steps.jl
+++ b/src/DynamicsMethods/IntegrationAlgorithms/steps.jl
@@ -1,3 +1,4 @@
+using NQCDynamics: get_ring_polymer_temperature
 
 function step_B!(v2, v1, dt, k)
     @.. broadcast=false v2 = muladd(dt, k, v1)
@@ -109,7 +110,7 @@ function step_O!(friction::LangevinCache, integrator, v::RingPolymerArray, r::Ri
     @unpack W, p, dt, sqdt = integrator
     @unpack c1, c2, sqrtmass, σ = friction
 
-    @.. σ = sqrt(get_temperature(p, t)) * sqrtmass
+    @.. σ = sqrt(get_ring_polymer_temperature(p, t)) * sqrtmass
 
     for i in axes(r, 3)
         for j in RingPolymerArrays.quantumindices(v)

--- a/src/Estimators.jl
+++ b/src/Estimators.jl
@@ -17,7 +17,7 @@ using NQCDynamics:
     natoms,
     nbeads,
     masses,
-    get_temperature
+    get_ring_polymer_temperature
 
 using StatsBase: mean
 using ComponentArrays: ComponentVector
@@ -90,7 +90,7 @@ function kinetic_energy(sim::RingPolymerSimulation, r::AbstractArray{T,3}) where
 
     Calculators.evaluate_derivative!(sim.calculator, r)
 
-    kinetic = ndofs(sim) * natoms(sim) * get_temperature(sim)
+    kinetic = ndofs(sim) * natoms(sim) * get_ring_polymer_temperature(sim)
 
     for I in CartesianIndices(r)
         kinetic += (r[I] - centroid[I[1], I[2]]) * sim.calculator.derivative[I] 

--- a/src/InitialConditions/ThermalMonteCarlo.jl
+++ b/src/InitialConditions/ThermalMonteCarlo.jl
@@ -15,6 +15,7 @@ using NQCDynamics:
     Simulation,
     RingPolymerSimulation,
     get_temperature,
+    get_ring_polymer_temperature,
     DynamicsUtils,
     RingPolymers,
     Calculators,
@@ -82,7 +83,7 @@ function get_deriv_function(sim::Simulation)
 end
 
 function get_density_function(sim::RingPolymerSimulation)
-    temperature = get_temperature(sim)
+    temperature = get_ring_polymer_temperature(sim)
     function density(r)
         r_local = reshape(copy(r), size(sim))
         RingPolymerArrays.transform_from_normal_modes!(r_local, sim.beads.transformation)
@@ -146,7 +147,7 @@ function RingPolymerProposal(sim::RingPolymerSimulation, σ, move_ratio, interna
         else
             for j in range(sim.atoms)
                 if j in sim.beads.quantum_atoms
-                    Δ = sqrt(get_temperature(sim) / (sim.atoms.masses[j] * ωₖ[i]^2))
+                    Δ = sqrt(get_ring_polymer_temperature(sim) / (sim.atoms.masses[j] * ωₖ[i]^2))
                     distribution = Normal(0, Δ)
                 else
                     distribution = Dirac(0)

--- a/src/simulations.jl
+++ b/src/simulations.jl
@@ -79,16 +79,16 @@ end
 Base.size(sim::Simulation) = (ndofs(sim), natoms(sim))
 Base.size(sim::RingPolymerSimulation) = (ndofs(sim), natoms(sim), RingPolymers.nbeads(sim))
 
-function get_temperature(sim::Simulation, t::Real=0)
+function get_temperature(sim::AbstractSimulation, t::Real=0)
     t = auconvert(u"fs", t)
     get_temperature(sim.temperature, t)
 end
-function get_temperature(sim::RingPolymerSimulation, t::Real=0)
-    t = auconvert(u"fs", t)
-    get_temperature(sim.temperature, t) * length(sim.beads)
-end
 get_temperature(temperature::Number, t=0) = austrip(temperature)
 get_temperature(temperature::Function, t=0) = austrip(temperature(t))
+
+function get_ring_polymer_temperature(sim::RingPolymerSimulation, t::Real=0)
+    return get_temperature(sim, t) * nbeads(sim)
+end
 
 function Base.show(io::IO, sim::Simulation{M}) where {M}
     print(io, "Simulation{$M}:\n  ", sim.atoms, "\n  ", sim.calculator.model)

--- a/test/Core/calculators.jl
+++ b/test/Core/calculators.jl
@@ -305,24 +305,3 @@ end
     @test @allocated(Calculators.evaluate_derivative!(calc, r)) == 0
     @test @allocated(Calculators.evaluate_friction!(calc, r)) == 1920
 end
-
-@testset "DiabaticFrictionCalculator" begin
-    model = NQCModels.MiaoSubotnik()
-    calc = Calculators.DiabaticFrictionCalculator{Float64}(model, 1) 
-    r = rand(1,1)
-
-    Calculators.get_nonadiabatic_coupling(calc, r)
-
-    Calculators.evaluate_potential!(calc, r)
-    Calculators.evaluate_derivative!(calc, r)
-    Calculators.evaluate_eigen!(calc, r)
-    Calculators.evaluate_adiabatic_derivative!(calc, r)
-    Calculators.evaluate_nonadiabatic_coupling!(calc, r)
-
-    @test @allocated(Calculators.evaluate_potential!(calc, r)) == 0
-    @test @allocated(Calculators.evaluate_derivative!(calc, r)) == 0
-    @test @allocated(Calculators.evaluate_eigen!(calc, r)) == 56896 # nonzero due to eigenroutines
-    @test @allocated(Calculators.evaluate_adiabatic_derivative!(calc, r)) == 0
-    @test @allocated(Calculators.evaluate_nonadiabatic_coupling!(calc, r)) == 0
-end
-

--- a/test/Core/calculators.jl
+++ b/test/Core/calculators.jl
@@ -270,6 +270,27 @@ end
     @test @allocated(Calculators.evaluate_nonadiabatic_coupling!(calc, r)) == 0
 end
 
+@testset "RingPolymerLargeDiabaticCalculator" begin
+    model = NQCModels.MiaoSubotnik()
+    calc = Calculators.RingPolymerLargeDiabaticCalculator{Float64}(model, 1, 10) 
+    r = rand(1, 1, 10)
+
+    Calculators.get_nonadiabatic_coupling(calc, r)
+    @test all(x->x==1, values(calc.stats))
+
+    Calculators.evaluate_potential!(calc, r)
+    Calculators.evaluate_derivative!(calc, r)
+    Calculators.evaluate_eigen!(calc, r)
+    Calculators.evaluate_adiabatic_derivative!(calc, r)
+    Calculators.evaluate_nonadiabatic_coupling!(calc, r)
+
+    @test @allocated(Calculators.evaluate_potential!(calc, r)) == 0
+    @test @allocated(Calculators.evaluate_derivative!(calc, r)) == 0
+    @test @allocated(Calculators.evaluate_eigen!(calc, r)) == 568960 # nonzero due to eigenroutines
+    @test @allocated(Calculators.evaluate_adiabatic_derivative!(calc, r)) == 0
+    @test @allocated(Calculators.evaluate_nonadiabatic_coupling!(calc, r)) == 0
+end
+
 @testset "FrictionCalculator" begin
     model = CompositeFrictionModel(Free(), RandomFriction(1))
     calc = Calculators.FrictionCalculator{Float64}(model, 1) 

--- a/test/Core/simulations.jl
+++ b/test/Core/simulations.jl
@@ -31,6 +31,15 @@ model = NQCModels.Free()
     @test NQCDynamics.get_temperature(sim, 1) isa Real
 end
 
+@testset "get_ring_polymer_temperature" begin
+    sim = RingPolymerSimulation(atoms, model, 10; temperature=10u"K")
+    @test NQCDynamics.get_ring_polymer_temperature(sim) isa Real
+    sim = RingPolymerSimulation(atoms, model, 10; temperature=x->10u"K")
+    @test NQCDynamics.get_ring_polymer_temperature(sim) isa Real
+    sim = RingPolymerSimulation(atoms, model, 10; temperature=10)
+    @test NQCDynamics.get_ring_polymer_temperature(sim, 1) isa Real
+end
+
 @testset "nfunctions and size" begin
     sim = Simulation(atoms, model)
     @test natoms(sim) == 2

--- a/test/Dynamics/diabatic_mdef.jl
+++ b/test/Dynamics/diabatic_mdef.jl
@@ -34,3 +34,16 @@ model = WideBandBath(thossmodel; step=ΔE, bandmin=-fld(nstates,2)*ΔE, bandmax=
     @test friction_gb ≈ friction_ongb rtol=1e-1
     @test friction_dq ≈ friction_ongb rtol=1e-1
 end
+
+@testset "Simulation{DiabaticMDEF}" begin
+    sim = Simulation{DiabaticMDEF}(atoms, model; temperature=T, friction_method=ClassicalMethods.WideBandExact(model.ρ))
+    u = DynamicsVariables(sim, rand(1,1), rand(1,1))
+    run_trajectory(u, (0.0, 1.0), sim; dt=0.1)
+end
+
+@testset "RingPolymerSimulation{DiabaticMDEF}" begin
+    n_beads = 10
+    sim = RingPolymerSimulation{DiabaticMDEF}(atoms, model, n_beads; temperature=T, friction_method=ClassicalMethods.WideBandExact(model.ρ))
+    u = DynamicsVariables(sim, rand(1,1,n_beads), rand(1,1,n_beads))
+    run_trajectory(u, (0.0, 1.0), sim; dt=0.1)
+end

--- a/test/Dynamics/diabatic_mdef.jl
+++ b/test/Dynamics/diabatic_mdef.jl
@@ -1,0 +1,36 @@
+using Test
+using NQCDynamics
+using Unitful, UnitfulAtomic
+
+atoms = Atoms(1u"u")
+nstates = 100
+x = austrip.((1.0:0.1:5)u"Å")
+Γ = 0.25 # 0.02, 0.1, 0.25, 0.5, 1.0, 2.0
+ΔE = Γ / 140
+T = 5ΔE
+thossmodel = ErpenbeckThoss(;Γ)
+model = WideBandBath(thossmodel; step=ΔE, bandmin=-fld(nstates,2)*ΔE, bandmax=ΔE*fld(nstates,2))
+
+@testset "Friction comparison" begin
+    function fric(r, sim)
+        r = [r;;]
+        Λ = zeros(1, 1)
+        t = 0.0
+        ClassicalMethods.friction!(Λ, r, sim, t)
+        return Λ[1]
+    end
+
+    σ = 20ΔE
+    sim = Simulation{DiabaticMDEF}(atoms, model; temperature=T, friction_method=ClassicalMethods.DirectQuadrature(model.ρ))
+    friction_dq = fric.(x, sim)
+    sim = Simulation{DiabaticMDEF}(atoms, model; temperature=T, friction_method=ClassicalMethods.WideBandExact(model.ρ))
+    friction_wb = fric.(x, sim)
+    sim = Simulation{DiabaticMDEF}(atoms, model; temperature=T, friction_method=ClassicalMethods.GaussianBroadening(σ))
+    friction_gb = fric.(x, sim)
+    sim = Simulation{DiabaticMDEF}(atoms, model; temperature=T, friction_method=ClassicalMethods.OffDiagonalGaussianBroadening(σ))
+    friction_ongb = fric.(x, sim)
+
+    @test friction_dq ≈ friction_wb rtol=1e-1
+    @test friction_gb ≈ friction_ongb rtol=1e-1
+    @test friction_dq ≈ friction_ongb rtol=1e-1
+end

--- a/test/Dynamics/mdef.jl
+++ b/test/Dynamics/mdef.jl
@@ -2,7 +2,6 @@ using Test
 using NQCDynamics
 using Unitful
 using UnitfulAtomic
-using RecursiveArrayTools: ArrayPartition
 using LinearAlgebra: diag
 using ComponentArrays
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -24,6 +24,7 @@ if GROUP == "All" || GROUP == "Dynamics"
     @time @safetestset "Langevin Tests" begin include("Dynamics/langevin.jl") end
     @time @safetestset "MDEF BAOAB Tests" begin include("Dynamics/mdef_baoab.jl") end
     @time @safetestset "MDEF Tests" begin include("Dynamics/mdef.jl") end
+    @time @safetestset "DiabaticMDEF Tests" begin include("Dynamics/diabatic_mdef.jl") end
     @time @safetestset "RPMDEF Tests" begin include("Dynamics/rpmdef.jl") end
     @time @safetestset "BCBwithTsit5 Tests" begin include("Dynamics/bcbwithtsit5.jl") end
     @time @safetestset "FSSH Tests" begin include("Dynamics/fssh.jl") end


### PR DESCRIPTION
This pull request includes lots of features related to MDEF simulations with model Hamiltonians.

- The old friction evaluation has been replaced with multiple choices of method.
- The DiabaticFrictionCalculators have been removed as they are no longer needed.
- A RingPolymerLargeDiabaticCalculator has been added to allow for ring polymer simulations of this type.