### PR TITLE
QuantiseDiatomic updates

### DIFF
--- a/src/DynamicsOutputs.jl
+++ b/src/DynamicsOutputs.jl
@@ -64,7 +64,7 @@ export OutputPosition
 
 Output the position of the ring polymer centroid at each timestep during the trajectory.
 """
-OutputCentroidPosition(sol, i) = [get_centroid(get_position(u)) for u in sol.u]
+OutputCentroidPosition(sol, i) = [get_centroid(get_positions(u)) for u in sol.u]
 export OutputCentroidPosition
 
 """

--- a/src/InitialConditions/QuantisedDiatomic/QuantisedDiatomic.jl
+++ b/src/InitialConditions/QuantisedDiatomic/QuantisedDiatomic.jl
@@ -44,9 +44,9 @@ include("energy_evaluation.jl")
 include("binding_curve.jl")
 include("random_configuration.jl")
 
-struct EffectivePotential{T,B,F}
+struct EffectivePotential{JType,T,B,F}
     μ::T
-    J::Int
+    J::JType
     binding_curve::BindingCurve{T,B,F}
 end
 
@@ -415,7 +415,7 @@ function quantise_diatomic(sim::Simulation, v::Matrix, r::Matrix, binding_curve:
     E = k + p
 
     L = total_angular_momentum(r_com, p_com)
-    J = round(Int, (sqrt(1 + 4 * L^2) - 1) / 2) # L^2 = J(J+1)ħ^2
+    J = (sqrt(1+4*L^2) - 1) / 2 # L^2 = J(J+1)ħ^2
 
     μ = reduced_mass(masses(sim)[atom_indices])
 
@@ -437,7 +437,7 @@ function quantise_diatomic(sim::Simulation, v::Matrix, r::Matrix, binding_curve:
     show_timer && show(TIMER)
 
     @debug "Found ν=$ν"
-    return round(Int, ν), J
+    return round(Int, ν), round(Int, J)
 end
 
 function quantise_1D_vibration(model::AdiabaticModel, μ::Real, r::Real, v::Real;

--- a/src/InitialConditions/QuantisedDiatomic/QuantisedDiatomic.jl
+++ b/src/InitialConditions/QuantisedDiatomic/QuantisedDiatomic.jl
@@ -256,7 +256,10 @@ end
         height=10, normal_vector=[0, 0, 1])
 
 Quantise the vibrational and rotational degrees of freedom for the specified
-positions and velocities
+positions and velocities. 
+
+If the potential can be evaluated for the diatomic only, independent of position, 
+supplying a `Simulation` for just the diatomic will speed up evaluation. 
 
 When evaluating the potential, the molecule is moved to `height` in direction `normal_vector`.
 If the potential is independent of centre of mass position, this has no effect.
@@ -284,6 +287,8 @@ function quantise_diatomic(sim::Simulation, v::Matrix, r::Matrix;
     r, slab = separate_slab_and_molecule(atom_indices, r)
     v, slab_v = separate_slab_and_molecule(atom_indices, v)
     environment = EvaluationEnvironment(atom_indices, size(sim), slab, austrip(height), surface_normal)
+
+    @debug "After PBC check and separation from slab, diatomic positions are:\n$(r)"
 
     r_com = subtract_centre_of_mass(r, masses(sim)[atom_indices])
     v_com = subtract_centre_of_mass(v, masses(sim)[atom_indices])

--- a/src/InitialConditions/QuantisedDiatomic/QuantisedDiatomic.jl
+++ b/src/InitialConditions/QuantisedDiatomic/QuantisedDiatomic.jl
@@ -273,7 +273,7 @@ function quantise_diatomic(sim::Simulation, v::Matrix, r::Matrix;
     if isa(sim.cell,PeriodicCell)
         # If the simulation used a `PeriodicCell`, translate `atom_indices` so they are at their minimum distance. (This is necessary if atoms were translated back into the original unit cell)
         translations=[[i,j,k] for i in -max_translation:max_translation for j in -max_translation:max_translation for k in -max_translation:max_translation]
-        which_translation=argmin([norm(abs.(r[:,atom_indices[1]]-r[:,atom_indices[2]]+sim.cell.vectors*operation)) for operation in translations])
+        which_translation=argmin([norm(abs.(r[:,atom_indices[2]]-r[:,atom_indices[1]]+sim.cell.vectors*operation)) for operation in translations])
         # Translate one atom for minimal distance. 
         if translations[which_translation]!=[0,0,0]
             r[:,atom_indices[2]].=r[:,atom_indices[2]]+sim.cell.vectors*translations[which_translation]

--- a/src/InitialConditions/QuantisedDiatomic/QuantisedDiatomic.jl
+++ b/src/InitialConditions/QuantisedDiatomic/QuantisedDiatomic.jl
@@ -280,6 +280,7 @@ function quantise_diatomic(sim::Simulation, v::Matrix, r::Matrix;
     end
 
     r, slab = separate_slab_and_molecule(atom_indices, r)
+    v, slab_v = separate_slab_and_molecule(atom_indices, v)
     environment = EvaluationEnvironment(atom_indices, size(sim), slab, austrip(height), surface_normal)
 
     r_com = subtract_centre_of_mass(r, masses(sim)[atom_indices])

--- a/src/InitialConditions/QuantisedDiatomic/QuantisedDiatomic.jl
+++ b/src/InitialConditions/QuantisedDiatomic/QuantisedDiatomic.jl
@@ -58,9 +58,9 @@ function (effective_potential::EffectivePotential)(r)
     return rotational + potential
 end
 
-struct RadialMomentum{T,B,F}
+struct RadialMomentum{JType,T,B,F}
     total_energy::T
-    V::EffectivePotential{T,B,F}
+    V::EffectivePotential{JType,T,B,F}
 end
 
 function (radial_momentum::RadialMomentum)(r)

--- a/src/InitialConditions/QuantisedDiatomic/QuantisedDiatomic.jl
+++ b/src/InitialConditions/QuantisedDiatomic/QuantisedDiatomic.jl
@@ -317,6 +317,7 @@ function quantise_diatomic(sim::Simulation, v::Matrix, r::Matrix;
     TimerOutputs.complement!(TIMER)
     show_timer && show(TIMER)
 
+    @debug "Found ν=$ν"
     return round(Int, ν), J
 end
 

--- a/src/InitialConditions/QuantisedDiatomic/QuantisedDiatomic.jl
+++ b/src/InitialConditions/QuantisedDiatomic/QuantisedDiatomic.jl
@@ -27,7 +27,7 @@ using UnicodePlots: lineplot, lineplot!, DotCanvas, histogram
 using Optim: Optim
 using Roots: Roots
 using TimerOutputs: TimerOutputs, @timeit
-using Interpolations: interpolate, BSpline, Cubic, Line, OnGrid, scale, hessian
+using Interpolations: interpolate, BSpline, Cubic, Line, OnGrid, scale, hessian, knots
 
 using NQCDynamics: Simulation, Calculators, DynamicsUtils, masses
 using NQCBase: Atoms, PeriodicCell, InfiniteCell

--- a/src/InitialConditions/QuantisedDiatomic/QuantisedDiatomic.jl
+++ b/src/InitialConditions/QuantisedDiatomic/QuantisedDiatomic.jl
@@ -265,7 +265,7 @@ Otherwise, be sure to modify these parameters to give the intended behaviour.
 function quantise_diatomic(sim::Simulation, v::Matrix, r::Matrix;
     height=10.0, surface_normal=[0, 0, 1.0], atom_indices=[1, 2],
     show_timer=false, reset_timer=false,
-    bond_lengths=0.5:0.01:5.0, max_translation=1, debug=false
+    bond_lengths=0.5:0.01:5.0, max_translation=1
 )
 
     reset_timer && TimerOutputs.reset_timer!(TIMER)
@@ -277,7 +277,7 @@ function quantise_diatomic(sim::Simulation, v::Matrix, r::Matrix;
         # Translate one atom for minimal distance. 
         if translations[which_translation]!=[0,0,0]
             r[:,atom_indices[2]].=r[:,atom_indices[2]]+sim.cell.vectors*translations[which_translation]
-            @info "Using a periodic copy of atom "*string(atom_indices[end])*"  to bring it closer to atom "*string(atom_indices[begin])
+            @debug "Using a periodic copy of atom "*string(atom_indices[end])*"  to bring it closer to atom "*string(atom_indices[begin])
         end
     end
 
@@ -300,10 +300,8 @@ function quantise_diatomic(sim::Simulation, v::Matrix, r::Matrix;
 
     binding_curve = calculate_binding_curve(bond_lengths, sim.calculator.model, environment)
 
-    if debug
-        println(k,"\n", p,"\n", E,"\n", L,"\n", J)
-    end
-    
+    @debug "k=$k\np=$p\nE=$E\nL=$L\nJ=$J\n"
+
     V = EffectivePotential(μ, J, binding_curve)
 
     r₁, r₂ = @timeit TIMER "Finding bounds" find_integral_bounds(E, V)

--- a/src/InitialConditions/QuantisedDiatomic/QuantisedDiatomic.jl
+++ b/src/InitialConditions/QuantisedDiatomic/QuantisedDiatomic.jl
@@ -270,7 +270,7 @@ function quantise_diatomic(sim::Simulation, v::Matrix, r::Matrix;
 
     reset_timer && TimerOutputs.reset_timer!(TIMER)
 
-    if typeof(sim.cell)==PeriodicCell
+    if isa(sim.cell,PeriodicCell)
         # If the simulation used a `PeriodicCell`, translate `atom_indices` so they are at their minimum distance. (This is necessary if atoms were translated back into the original unit cell)
         translations=[[i,j,k] for i in -max_translation:max_translation for j in -max_translation:max_translation for k in -max_translation:max_translation]
         which_translation=argmin([norm(abs.(r[:,atom_indices[1]]-r[:,atom_indices[2]]+sim.cell.vectors*operation)) for operation in translations])

--- a/src/InitialConditions/QuantisedDiatomic/binding_curve.jl
+++ b/src/InitialConditions/QuantisedDiatomic/binding_curve.jl
@@ -1,3 +1,4 @@
+using Optim: Optim
 
 struct BindingCurve{T,B,F}
     bond_lengths::B
@@ -11,9 +12,8 @@ function calculate_binding_curve(
     bond_lengths::AbstractVector, model::AdiabaticModel, environment::EvaluationEnvironment
 )
     potential = calculate_diatomic_energy.(bond_lengths, model, environment) # Calculate binding curve
-    potential_minimum, index = findmin(potential)
-    equilibrium_bond_length = bond_lengths[index]
     fit = fit_binding_curve(bond_lengths, potential)
+    equilibrium_bond_length, potential_minimum = find_minimum(fit)
     return BindingCurve(bond_lengths, potential, equilibrium_bond_length, potential_minimum, fit)
 end
 
@@ -21,6 +21,12 @@ function fit_binding_curve(bond_lengths, binding_curve)
     itp = interpolate(binding_curve, BSpline(Cubic(Line(OnGrid()))))
     sitp = scale(itp, bond_lengths)
     return sitp
+end
+
+function find_minimum(fit)
+    grid = knots(fit)
+    results = Optim.optimize(fit, minimum(grid), maximum(grid), Optim.Brent())
+    return Optim.minimizer(results), Optim.minimum(results)
 end
 
 function calculate_force_constant(binding_curve)


### PR DESCRIPTION
Includes handling for periodic copies of atoms for structures/simulations with a `PeriodicCell` to quantise a periodic copy with the shortest possible bond length. 
This fixes some occurrences of #292. 