### PR TITLE
Update documenter to v1 and add docs profiling info

### DIFF
--- a/docs/Project.toml
+++ b/docs/Project.toml
@@ -26,5 +26,5 @@ Unitful = "1986cc42-f94f-5a68-af5c-568840ba703d"
 UnitfulAtomic = "a7773ee8-282e-5fa2-be4e-bd808c38a91a"
 
 [compat]
-Documenter = "0.27"
+Documenter = "1"
 DocumenterCitations = "1"

--- a/docs/add_profiling_info.jl
+++ b/docs/add_profiling_info.jl
@@ -1,0 +1,37 @@
+
+function add_text_blocks(file)
+    preamble = """
+    ```@setup logging
+    @info "Expanding $file..."
+    start_time = time()
+    ```
+    """
+
+    postamble = """
+    ```@setup logging
+    runtime = round(time() - start_time; digits=2)
+    @info "...done after \$runtime s."
+    ```
+    """
+
+    (tmppath, tmpio) = mktemp()
+    open(file) do io
+        write(tmpio, preamble)
+        for line in eachline(io, keep=true) # keep so the new line isn't chomped
+            write(tmpio, line)
+        end
+        write(tmpio, postamble)
+    end
+    close(tmpio)
+    mv(tmppath, file, force=true)
+end
+
+
+for (root, dirs, files) in walkdir("src")
+    for file in files
+        if splitext(file)[2] == ".md"
+            filepath = joinpath(root, file)
+            add_text_blocks(filepath)
+        end
+    end
+end

--- a/docs/make.jl
+++ b/docs/make.jl
@@ -3,10 +3,6 @@ using DocumenterCitations
 using NQCBase, NQCModels, NQCDistributions, NQCDynamics
 using CubeLDFAModel, NNInterfaces
 
-DocMeta.setdocmeta!(NQCDynamics, :DocTestSetup, :(using NQCDynamics); recursive=true)
-DocMeta.setdocmeta!(NQCModels, :DocTestSetup, :(using NQCModels, Symbolics); recursive=true)
-DocMeta.setdocmeta!(NQCBase, :DocTestSetup, :(using NQCBase); recursive=true)
-
 bib = CitationBibliography(joinpath(@__DIR__, "references.bib"))
 
 function find_all_files(directory)
@@ -16,16 +12,15 @@ function find_all_files(directory)
     )
 end
 
-@time makedocs(
-    bib,
+@time makedocs(;
+    plugins=[bib],
     sitename="NQCDynamics.jl",
     modules=[NQCDynamics, NQCDistributions, NQCModels, NQCBase, CubeLDFAModel],
-    strict=true,
+    doctest=false,
     format=Documenter.HTML(
         prettyurls=get(ENV, "CI", nothing) == "true",
         canonical="https://nqcd.github.io/NQCDynamics.jl/stable/",
         assets=["assets/favicon.ico", "assets/citations.css"],
-        ansicolor=true,
     ),
     authors="James Gardner and contributors.",
     pages=[

--- a/docs/src/NQCDistributions/overview.md
+++ b/docs/src/NQCDistributions/overview.md
@@ -1,3 +1,7 @@
+```@setup logging
+@info "Expanding src/NQCDistributions/overview.md..."
+start_time = time()
+```
 # NQCDistributions.jl
 
 # Storing and sampling distributions
@@ -128,3 +132,7 @@ of the distribution is handled separately by each of the different methods.
 
 To learn how to generate configurations to use with the [`DynamicalDistribution`](@ref),
 read on to the next sections about the included sampling methods.
+```@setup logging
+runtime = round(time() - start_time; digits=2)
+@info "...done after $runtime s."
+```

--- a/docs/src/NQCModels/analyticmodels.md
+++ b/docs/src/NQCModels/analyticmodels.md
@@ -1,3 +1,7 @@
+```@setup logging
+@info "Expanding src/NQCModels/analyticmodels.md..."
+start_time = time()
+```
 # Analytic model library
 
 This page plots many of the analytic models included in `NQCDynamics`.
@@ -92,4 +96,8 @@ z = range(-0.5, 4.0, length=200)
 
 contour(x, z, v1, color=:blue, levels=0:0.01:0.1, label="V11", colorbar=false)
 contour!(x, z, v2, color=:red, levels=0:0.01:0.1, label="V22")
+```
+```@setup logging
+runtime = round(time() - start_time; digits=2)
+@info "...done after $runtime s."
 ```

--- a/docs/src/NQCModels/ase.md
+++ b/docs/src/NQCModels/ase.md
@@ -1,3 +1,7 @@
+```@setup logging
+@info "Expanding src/NQCModels/ase.md..."
+start_time = time()
+```
 # ASE interface
 
 The easiest way to obtain potentials and forces from established codes is to
@@ -23,12 +27,12 @@ associated calculator to implement the required [`potential`](@ref) and
 First, it is necessary to import `ase` and create the `ase.Atoms` object and attach
 the desired calculator. This works exactly as in Python:
 ```@example ase
-using PyCall
+using PythonCall: pyimport, pylist
+using ASEconvert
 
-ase = pyimport("ase")
 emt = pyimport("ase.calculators.emt")
 
-h2 = ase.Atoms("H2", [(0, 0, 0), (0, 0, 0.74)])
+h2 = ase.Atoms("H2", pylist([(0, 0, 0), (0, 0, 0.74)]))
 h2.calc = emt.EMT()
 nothing # hide
 ```
@@ -53,3 +57,7 @@ derivative(model, rand(3, 2))
     [SchNetPack (SPK)](https://github.com/atomistic-machine-learning/schnetpack) by
     passing their ASE calculator to the `AdiabaticASEModel`.
     Take a look at [Neural network models](@ref) to learn more.
+```@setup logging
+runtime = round(time() - start_time; digits=2)
+@info "...done after $runtime s."
+```

--- a/docs/src/NQCModels/frictionmodels.md
+++ b/docs/src/NQCModels/frictionmodels.md
@@ -1,3 +1,7 @@
+```@setup logging
+@info "Expanding src/NQCModels/frictionmodels.md..."
+start_time = time()
+```
 # [Electronic friction models](@id models-friction)
 
 To perform [molecular dynamics with electronic friction (MDEF)](@ref mdef-dynamics)
@@ -69,3 +73,7 @@ to obtain the time-dependent perturbation theory friction from the atomic positi
 As with LDFA, one of these models is used in the
 [reactive scattering example](@ref example-h2scattering).
 
+```@setup logging
+runtime = round(time() - start_time; digits=2)
+@info "...done after $runtime s."
+```

--- a/docs/src/NQCModels/neuralnetworkmodels.md
+++ b/docs/src/NQCModels/neuralnetworkmodels.md
@@ -1,3 +1,7 @@
+```@setup logging
+@info "Expanding src/NQCModels/neuralnetworkmodels.md..."
+start_time = time()
+```
 # Neural network models
 
 Using the [ASE interface](@ref) we can directly use models trained using
@@ -58,4 +62,8 @@ r = [0 0; 0 0; 0 ustrip(auconvert(0.74u"Å"))]
 
 potential(model, r)
 derivative(model, r)
+```
+```@setup logging
+runtime = round(time() - start_time; digits=2)
+@info "...done after $runtime s."
 ```

--- a/docs/src/NQCModels/overview.md
+++ b/docs/src/NQCModels/overview.md
@@ -1,3 +1,7 @@
+```@setup logging
+@info "Expanding src/NQCModels/overview.md..."
+start_time = time()
+```
 # NQCModels.jl
 
 To perform nonadiabatic molecular dynamics simulations, it is necessary to define
@@ -102,3 +106,7 @@ AbstractTrees.print_tree(Model) # hide
 
     To learn more about NQCModels.jl and learn how to implement new models,
     visit the [developer documentation](@ref devdocs-model).
+```@setup logging
+runtime = round(time() - start_time; digits=2)
+@info "...done after $runtime s."
+```

--- a/docs/src/api/NQCBase/nqcbase.md
+++ b/docs/src/api/NQCBase/nqcbase.md
@@ -1,6 +1,14 @@
+```@setup logging
+@info "Expanding src/api/NQCBase/nqcbase.md..."
+start_time = time()
+```
 
 # NQCBase
 
 ```@autodocs
 Modules=[NQCBase]
+```
+```@setup logging
+runtime = round(time() - start_time; digits=2)
+@info "...done after $runtime s."
 ```

--- a/docs/src/api/NQCDistributions/nqcdistributions.md
+++ b/docs/src/api/NQCDistributions/nqcdistributions.md
@@ -1,6 +1,14 @@
+```@setup logging
+@info "Expanding src/api/NQCDistributions/nqcdistributions.md..."
+start_time = time()
+```
 
 # NQCDistributions
 
 ```@autodocs
 Modules=[NQCDistributions]
+```
+```@setup logging
+runtime = round(time() - start_time; digits=2)
+@info "...done after $runtime s."
 ```

--- a/docs/src/api/NQCDynamics/calculators.md
+++ b/docs/src/api/NQCDynamics/calculators.md
@@ -1,5 +1,13 @@
+```@setup logging
+@info "Expanding src/api/NQCDynamics/calculators.md..."
+start_time = time()
+```
 # Calculators
 
 ```@autodocs
 Modules=[NQCDynamics.Calculators]
+```
+```@setup logging
+runtime = round(time() - start_time; digits=2)
+@info "...done after $runtime s."
 ```

--- a/docs/src/api/NQCDynamics/dynamicsmethods.md
+++ b/docs/src/api/NQCDynamics/dynamicsmethods.md
@@ -1,3 +1,7 @@
+```@setup logging
+@info "Expanding src/api/NQCDynamics/dynamicsmethods.md..."
+start_time = time()
+```
 
 # DynamicsMethods
 
@@ -33,4 +37,8 @@ Modules=[NQCDynamics.DynamicsMethods.EhrenfestMethods]
 
 ```@autodocs
 Modules=[NQCDynamics.DynamicsMethods.IntegrationAlgorithms]
+```
+```@setup logging
+runtime = round(time() - start_time; digits=2)
+@info "...done after $runtime s."
 ```

--- a/docs/src/api/NQCDynamics/dynamicsoutputs.md
+++ b/docs/src/api/NQCDynamics/dynamicsoutputs.md
@@ -1,3 +1,7 @@
+```@setup logging
+@info "Expanding src/api/NQCDynamics/dynamicsoutputs.md..."
+start_time = time()
+```
 
 # DynamicsOutputs
 
@@ -14,4 +18,8 @@ Private=false
 ```@autodocs
 Modules=[NQCDynamics.DynamicsOutputs]
 Public=false
+```
+```@setup logging
+runtime = round(time() - start_time; digits=2)
+@info "...done after $runtime s."
 ```

--- a/docs/src/api/NQCDynamics/dynamicsutils.md
+++ b/docs/src/api/NQCDynamics/dynamicsutils.md
@@ -1,6 +1,14 @@
+```@setup logging
+@info "Expanding src/api/NQCDynamics/dynamicsutils.md..."
+start_time = time()
+```
 
 # DynamicsUtils
 
 ```@autodocs
 Modules=[NQCDynamics.DynamicsUtils]
+```
+```@setup logging
+runtime = round(time() - start_time; digits=2)
+@info "...done after $runtime s."
 ```

--- a/docs/src/api/NQCDynamics/ensembles.md
+++ b/docs/src/api/NQCDynamics/ensembles.md
@@ -1,6 +1,14 @@
+```@setup logging
+@info "Expanding src/api/NQCDynamics/ensembles.md..."
+start_time = time()
+```
 
 # Ensembles
 
 ```@autodocs
 Modules=[NQCDynamics.Ensembles]
+```
+```@setup logging
+runtime = round(time() - start_time; digits=2)
+@info "...done after $runtime s."
 ```

--- a/docs/src/api/NQCDynamics/estimators.md
+++ b/docs/src/api/NQCDynamics/estimators.md
@@ -1,6 +1,14 @@
+```@setup logging
+@info "Expanding src/api/NQCDynamics/estimators.md..."
+start_time = time()
+```
 
 # Estimators
 
 ```@autodocs
 Modules=[NQCDynamics.Estimators]
+```
+```@setup logging
+runtime = round(time() - start_time; digits=2)
+@info "...done after $runtime s."
 ```

--- a/docs/src/api/NQCDynamics/initialconditions.md
+++ b/docs/src/api/NQCDynamics/initialconditions.md
@@ -1,3 +1,7 @@
+```@setup logging
+@info "Expanding src/api/NQCDynamics/initialconditions.md..."
+start_time = time()
+```
 
 # InitialConditions
 
@@ -21,4 +25,8 @@ Modules=[NQCDynamics.InitialConditions.QuantisedDiatomic]
 
 ```@autodocs
 Modules=[NQCDynamics.InitialConditions.MetropolisHastings]
+```
+```@setup logging
+runtime = round(time() - start_time; digits=2)
+@info "...done after $runtime s."
 ```

--- a/docs/src/api/NQCDynamics/nonadiabaticmoleculardynamics.md
+++ b/docs/src/api/NQCDynamics/nonadiabaticmoleculardynamics.md
@@ -1,5 +1,13 @@
+```@setup logging
+@info "Expanding src/api/NQCDynamics/nonadiabaticmoleculardynamics.md..."
+start_time = time()
+```
 # NQCDynamics
 
 ```@autodocs
 Modules=[NQCDynamics]
+```
+```@setup logging
+runtime = round(time() - start_time; digits=2)
+@info "...done after $runtime s."
 ```

--- a/docs/src/api/NQCDynamics/numericutils.md
+++ b/docs/src/api/NQCDynamics/numericutils.md
@@ -1,6 +1,14 @@
+```@setup logging
+@info "Expanding src/api/NQCDynamics/numericutils.md..."
+start_time = time()
+```
 
 # Numerical utilities
 
 ```@autodocs
 Modules=[NQCDynamics.FastDeterminant]
+```
+```@setup logging
+runtime = round(time() - start_time; digits=2)
+@info "...done after $runtime s."
 ```

--- a/docs/src/api/NQCDynamics/ringpolymers.md
+++ b/docs/src/api/NQCDynamics/ringpolymers.md
@@ -1,6 +1,14 @@
+```@setup logging
+@info "Expanding src/api/NQCDynamics/ringpolymers.md..."
+start_time = time()
+```
 
 # RingPolymers
 
 ```@autodocs
 Modules=[NQCDynamics.RingPolymers]
+```
+```@setup logging
+runtime = round(time() - start_time; digits=2)
+@info "...done after $runtime s."
 ```

--- a/docs/src/api/NQCDynamics/timecorrelationfunctions.md
+++ b/docs/src/api/NQCDynamics/timecorrelationfunctions.md
@@ -1,6 +1,14 @@
+```@setup logging
+@info "Expanding src/api/NQCDynamics/timecorrelationfunctions.md..."
+start_time = time()
+```
 
 # TimeCorrelationFunctions
 
 ```@autodocs
 Modules=[NQCDynamics.TimeCorrelationFunctions]
+```
+```@setup logging
+runtime = round(time() - start_time; digits=2)
+@info "...done after $runtime s."
 ```

--- a/docs/src/api/NQCModels/adiabaticmodels.md
+++ b/docs/src/api/NQCModels/adiabaticmodels.md
@@ -1,6 +1,14 @@
+```@setup logging
+@info "Expanding src/api/NQCModels/adiabaticmodels.md..."
+start_time = time()
+```
 
 # AdiabaticModels
 
 ```@autodocs
 Modules=[NQCModels.AdiabaticModels]
+```
+```@setup logging
+runtime = round(time() - start_time; digits=2)
+@info "...done after $runtime s."
 ```

--- a/docs/src/api/NQCModels/cubeldfamodel.md
+++ b/docs/src/api/NQCModels/cubeldfamodel.md
@@ -1,6 +1,14 @@
+```@setup logging
+@info "Expanding src/api/NQCModels/cubeldfamodel.md..."
+start_time = time()
+```
 
 # CubeLDFAModel
 
 ```@autodocs
 Modules=[CubeLDFAModel]
+```
+```@setup logging
+runtime = round(time() - start_time; digits=2)
+@info "...done after $runtime s."
 ```

--- a/docs/src/api/NQCModels/diabaticmodels.md
+++ b/docs/src/api/NQCModels/diabaticmodels.md
@@ -1,6 +1,14 @@
+```@setup logging
+@info "Expanding src/api/NQCModels/diabaticmodels.md..."
+start_time = time()
+```
 
 # DiabaticModels
 
 ```@autodocs
 Modules=[NQCModels.DiabaticModels]
+```
+```@setup logging
+runtime = round(time() - start_time; digits=2)
+@info "...done after $runtime s."
 ```

--- a/docs/src/api/NQCModels/frictionmodels.md
+++ b/docs/src/api/NQCModels/frictionmodels.md
@@ -1,6 +1,14 @@
+```@setup logging
+@info "Expanding src/api/NQCModels/frictionmodels.md..."
+start_time = time()
+```
 
 # FrictionModels
 
 ```@autodocs
 Modules=[NQCModels.FrictionModels]
+```
+```@setup logging
+runtime = round(time() - start_time; digits=2)
+@info "...done after $runtime s."
 ```

--- a/docs/src/api/NQCModels/nninterfaces.md
+++ b/docs/src/api/NQCModels/nninterfaces.md
@@ -1,6 +1,14 @@
+```@setup logging
+@info "Expanding src/api/NQCModels/nninterfaces.md..."
+start_time = time()
+```
 
 # NNInterfaces
 
 ```@autodocs
 Modules=[NNInterfaces]
+```
+```@setup logging
+runtime = round(time() - start_time; digits=2)
+@info "...done after $runtime s."
 ```

--- a/docs/src/api/NQCModels/nonadiabaticmodels.md
+++ b/docs/src/api/NQCModels/nonadiabaticmodels.md
@@ -1,3 +1,7 @@
+```@setup logging
+@info "Expanding src/api/NQCModels/nonadiabaticmodels.md..."
+start_time = time()
+```
 
 # NQCModels
 
@@ -7,3 +11,7 @@ Modules=[NQCModels]
 
 
 
+```@setup logging
+runtime = round(time() - start_time; digits=2)
+@info "...done after $runtime s."
+```

--- a/docs/src/atoms.md
+++ b/docs/src/atoms.md
@@ -1,3 +1,7 @@
+```@setup logging
+@info "Expanding src/atoms.md..."
+start_time = time()
+```
 # [Handling Atoms](@id atoms)
 
 This package makes the choice to separate the atomic parameters from their positions and
@@ -82,3 +86,7 @@ AtomsIO.save_trajectory("Si.xyz", trajectory) # Save a trajectory
 AtomsIO also provides `load_system` and `load_trajectory` which can be converted to the
 NQCDynamics format as above to initialise simulations.
 Refer to [AtomsIO](https://mfherbst.github.io/AtomsIO.jl/stable/) for more information.
+```@setup logging
+runtime = round(time() - start_time; digits=2)
+@info "...done after $runtime s."
+```

--- a/docs/src/devdocs/diffeq.md
+++ b/docs/src/devdocs/diffeq.md
@@ -1,3 +1,7 @@
+```@setup logging
+@info "Expanding src/devdocs/diffeq.md..."
+start_time = time()
+```
 
 # DifferentialEquations.jl integration
 
@@ -56,3 +60,7 @@ the simulation cell, and the termination caused the simulation to exit early.
 
 The callback setup we're using is exactly that provided by DifferentialEquations.jl,
 if you want more details on callbacks, please refer to their [documentation](https://diffeq.sciml.ai/dev/features/callback_functions/#callbacks).
+```@setup logging
+runtime = round(time() - start_time; digits=2)
+@info "...done after $runtime s."
+```

--- a/docs/src/devdocs/models.md
+++ b/docs/src/devdocs/models.md
@@ -1,3 +1,7 @@
+```@setup logging
+@info "Expanding src/devdocs/models.md..."
+start_time = time()
+```
 # [Implementing a new model](@id devdocs-model)
 
 [NQCModels.jl](@ref) aims to provide a unified interface for defining model
@@ -49,3 +53,7 @@ For further examples, you can also take a look into the source code of the `NQCM
 package to see how the analytic models have been implemented. 
 If you have any issues or questions about implementing a new model, open up an issue on
 Github and we can work together to resolve the problem. 
+```@setup logging
+runtime = round(time() - start_time; digits=2)
+@info "...done after $runtime s."
+```

--- a/docs/src/devdocs/new_methods.md
+++ b/docs/src/devdocs/new_methods.md
@@ -1,3 +1,7 @@
+```@setup logging
+@info "Expanding src/devdocs/new_methods.md..."
+start_time = time()
+```
 
 # Contributing a new method
 
@@ -162,3 +166,7 @@ The `DifferentialEquations.jl` framework provides a simple interface for adding 
 algorithms, check out the [developer documentation](https://devdocs.sciml.ai/dev/)
 to learn how it works.
 You can also find some examples of custom algorithms in the `DynamicsMethods.IntegrationAlgorithms` module.
+```@setup logging
+runtime = round(time() - start_time; digits=2)
+@info "...done after $runtime s."
+```

--- a/docs/src/dynamicssimulations/dynamicsmethods/classical.md
+++ b/docs/src/dynamicssimulations/dynamicsmethods/classical.md
@@ -1,3 +1,7 @@
+```@setup logging
+@info "Expanding src/dynamicssimulations/dynamicsmethods/classical.md..."
+start_time = time()
+```
 # [Classical molecular dynamics](@id classical-dynamics)
 
 Classical (molecular) dynamics proceeds
@@ -32,4 +36,8 @@ u0 = DynamicsVariables(sim, zeros(3, 2), hcat(randn(3), randn(3).+1))
 traj = run_dynamics(sim, (0.0, 10.0), u0; dt=0.1, output=OutputPosition)
 
 plot(traj, :OutputPosition)
+```
+```@setup logging
+runtime = round(time() - start_time; digits=2)
+@info "...done after $runtime s."
 ```

--- a/docs/src/dynamicssimulations/dynamicsmethods/ehrenfest.md
+++ b/docs/src/dynamicssimulations/dynamicsmethods/ehrenfest.md
@@ -1,3 +1,7 @@
+```@setup logging
+@info "Expanding src/dynamicssimulations/dynamicsmethods/ehrenfest.md..."
+start_time = time()
+```
 # [Ehrenfest molecular dynamics](@id ehrenfest-dynamics)
 
 The Ehrenfest method is a mixed quantum-classical dynamics method in which the total wavefunction is factorized into slow (nuclear) variables, which are treated classically, and fast ones (electrons) which remain quantum-mechanical. In the Ehrenfest method, nuclei move according to classical mechanics on a potential energy surface given by the expectation value of the electronic Hamiltonian. 
@@ -44,4 +48,8 @@ momenta = reduce(vcat, final_velocities*atoms.masses[1])
 using Plots
 histogram(momenta)
 xlims!(-20,20)
+```
+```@setup logging
+runtime = round(time() - start_time; digits=2)
+@info "...done after $runtime s."
 ```

--- a/docs/src/dynamicssimulations/dynamicsmethods/fssh.md
+++ b/docs/src/dynamicssimulations/dynamicsmethods/fssh.md
@@ -1,3 +1,7 @@
+```@setup logging
+@info "Expanding src/dynamicssimulations/dynamicsmethods/fssh.md..."
+start_time = time()
+```
 # [Fewest-switches surface hopping (FSSH)](@id fssh-dynamics)
 
 Tully's FSSH [Tully1990](@cite) is one of the most popular methods for nonadiabatic
@@ -120,3 +124,7 @@ plot(traj, :OutputDiabaticPopulation)
 
 [Another example is available](@ref examples-tully-model-two) where we use FSSH and other
 methods to reproduce some of the results from [Tully1990](@cite).
+```@setup logging
+runtime = round(time() - start_time; digits=2)
+@info "...done after $runtime s."
+```

--- a/docs/src/dynamicssimulations/dynamicsmethods/langevin.md
+++ b/docs/src/dynamicssimulations/dynamicsmethods/langevin.md
@@ -1,3 +1,7 @@
+```@setup logging
+@info "Expanding src/dynamicssimulations/dynamicsmethods/langevin.md..."
+start_time = time()
+```
 # [Classical Langevin dynamics](@id langevin-dynamics)
 
 Langevin dynamics can be used to sample the canonical ensemble for a classical system.
@@ -122,3 +126,7 @@ Estimators.@estimate kinetic_energy(sim, traj[:OutputVelocity])
 ```
 Again, this takes a similar value since the total energy is evenly split between the kinetic
 and potential for a classical harmonic system.
+```@setup logging
+runtime = round(time() - start_time; digits=2)
+@info "...done after $runtime s."
+```

--- a/docs/src/dynamicssimulations/dynamicsmethods/mdef.md
+++ b/docs/src/dynamicssimulations/dynamicsmethods/mdef.md
@@ -1,3 +1,7 @@
+```@setup logging
+@info "Expanding src/dynamicssimulations/dynamicsmethods/mdef.md..."
+start_time = time()
+```
 # [Molecular dynamics with electronic friction (MDEF)](@id mdef-dynamics)
 
 ## Introduction
@@ -117,3 +121,7 @@ View the [friction models page](@ref models-friction) to learn about how this ca
 
     If you would like to see an example using both LDFA and TDPT during full dimensional
     dynamics, refer to the [reactive scattering example](@ref example-h2scattering).
+```@setup logging
+runtime = round(time() - start_time; digits=2)
+@info "...done after $runtime s."
+```

--- a/docs/src/dynamicssimulations/dynamicsmethods/nrpmd.md
+++ b/docs/src/dynamicssimulations/dynamicsmethods/nrpmd.md
@@ -1,3 +1,7 @@
+```@setup logging
+@info "Expanding src/dynamicssimulations/dynamicsmethods/nrpmd.md..."
+start_time = time()
+```
 # [Nonadiabatic ring polymer molecular dynamics (NRPMD)](@id nrpmd-dynamics)
 
 ## Theory
@@ -178,4 +182,8 @@ ensemble = run_dynamics(sim, (0.0, 30.0), distribution;
 plot(0:0.1:30, [p[1,1]-p[2,1] for p in ensemble[:PopulationCorrelationFunction]])
 xlabel!("Time")
 ylabel!("Population difference")
+```
+```@setup logging
+runtime = round(time() - start_time; digits=2)
+@info "...done after $runtime s."
 ```

--- a/docs/src/dynamicssimulations/dynamicsmethods/rpmd.md
+++ b/docs/src/dynamicssimulations/dynamicsmethods/rpmd.md
@@ -1,3 +1,7 @@
+```@setup logging
+@info "Expanding src/dynamicssimulations/dynamicsmethods/rpmd.md..."
+start_time = time()
+```
 # [Ring polymer molecular dynamics (RPMD)](@id rpmd-dynamics)
 
 Ring polymer molecular dynamics is a quantum dynamics methods that attempts
@@ -111,3 +115,7 @@ end
 Since this package is focused on nonadiabatic dynamics, you won't see much adiabatic RPMD
 elsewhere in the documentation, but it's useful to understand how the original adiabatic
 version works before moving on to the nonadiabatic extensions.
+```@setup logging
+runtime = round(time() - start_time; digits=2)
+@info "...done after $runtime s."
+```

--- a/docs/src/dynamicssimulations/dynamicsmethods/rpsh.md
+++ b/docs/src/dynamicssimulations/dynamicsmethods/rpsh.md
@@ -1,3 +1,7 @@
+```@setup logging
+@info "Expanding src/dynamicssimulations/dynamicsmethods/rpsh.md..."
+start_time = time()
+```
 # [Ring polymer surface hopping (RPSH)](@id rpsh-dynamics)
 
 Ring polymer surface hopping was one of the early attempts to extend
@@ -90,3 +94,7 @@ and it is possible that better results could be achieved using a free ring polym
 [Welsch2016](@cite) provides a theoretical description of how nonequilibrium simulations using RPMD
 should be performed. This techniques here should likely be applied to RPSH too.
 
+```@setup logging
+runtime = round(time() - start_time; digits=2)
+@info "...done after $runtime s."
+```

--- a/docs/src/dynamicssimulations/dynamicssimulations.md
+++ b/docs/src/dynamicssimulations/dynamicssimulations.md
@@ -1,3 +1,7 @@
+```@setup logging
+@info "Expanding src/dynamicssimulations/dynamicssimulations.md..."
+start_time = time()
+```
 # [Introduction](@id dynamicssimulations)
 
 Performing dynamics simulations is at the core of this package's functionality
@@ -92,3 +96,7 @@ plot(out, :OutputAdiabaticPopulation)
 
 All of the dynamics methods work in a similar way. For details on a specific method along with examples,
 please see the method specific page in the sidebar under `Dynamics methods`.
+```@setup logging
+runtime = round(time() - start_time; digits=2)
+@info "...done after $runtime s."
+```

--- a/docs/src/ensemble_simulations.md
+++ b/docs/src/ensemble_simulations.md
@@ -1,3 +1,7 @@
+```@setup logging
+@info "Expanding src/ensemble_simulations.md..."
+start_time = time()
+```
 # [Ensemble simulations](@id ensembles)
 
 Typically we'll be interested in computing observables based upon the statistics
@@ -123,3 +127,7 @@ Throughout the documentation, ensemble simulations like this one are used to dem
 many of the dynamics methods.
 Now that you have understood the contents of this page, all of the ensemble simulations
 will appear familiar.
+```@setup logging
+runtime = round(time() - start_time; digits=2)
+@info "...done after $runtime s."
+```

--- a/docs/src/examples/reactive_scattering.md
+++ b/docs/src/examples/reactive_scattering.md
@@ -1,3 +1,7 @@
+```@setup logging
+@info "Expanding src/examples/reactive_scattering.md..."
+start_time = time()
+```
 # [Reactive scattering from a metal surface](@id example-h2scattering)
 
 Our implementation allows us to simulate vibrational de-excitation probability during reactive scattering events at metal surfaces for any diatomic molecule 
@@ -153,3 +157,7 @@ individual trajectory.
 
 
 
+```@setup logging
+runtime = round(time() - start_time; digits=2)
+@info "...done after $runtime s."
+```

--- a/docs/src/examples/spinboson.md
+++ b/docs/src/examples/spinboson.md
@@ -1,3 +1,7 @@
+```@setup logging
+@info "Expanding src/examples/spinboson.md..."
+start_time = time()
+```
 # Ohmic spin-boson nonequilibrium population dynamics
 
 The spin-boson model is widely used as a model for condensed phase quantum dynamics.
@@ -77,3 +81,7 @@ We can see that even with just 100 trajectories, our Ehrenfest result closely ma
 The FSSH is quite clearly underconverged with only 100 trajectories due to the discontinuous
 nature of the individual trajectories.
 Feel free to try this for yourself and see what the converged FSSH result looks like!
+```@setup logging
+runtime = round(time() - start_time; digits=2)
+@info "...done after $runtime s."
+```

--- a/docs/src/examples/threestatemorse.md
+++ b/docs/src/examples/threestatemorse.md
@@ -1,3 +1,7 @@
+```@setup logging
+@info "Expanding src/examples/threestatemorse.md..."
+start_time = time()
+```
 # Time-dependent populations with the ThreeStateMorse model
 
 In this example we investigate the time-dependent populations of the three state
@@ -103,3 +107,7 @@ To reduce the build time for the documentation the results here are underconverg
 already it is clear that both of these methods come close to the exact result shown by [Coronado2001](@cite).
 After performing enough trajectories to converge the population dynamics,
 we would be better able to judge the effectiveness of FSSH and Ehrenfest at reproducing the exact quantum dynamics for this model.
+```@setup logging
+runtime = round(time() - start_time; digits=2)
+@info "...done after $runtime s."
+```

--- a/docs/src/examples/tully_scattering.md
+++ b/docs/src/examples/tully_scattering.md
@@ -1,3 +1,7 @@
+```@setup logging
+@info "Expanding src/examples/tully_scattering.md..."
+start_time = time()
+```
 # [Scattering probabilities for TullyModelTwo](@id examples-tully-model-two)
 
 In this section we aim to reproduce the results of Fig. 5 from [Tully1990](@cite).
@@ -108,3 +112,7 @@ state 1 and transmission on state 2 respectively.
 For this model, surface hopping is successful in closely approximating the exact quantum
 result, especially at higher momentum values.
 Refer to [Tully1990](@cite) and [Shakib2017](@cite) for a detailed discussion of the results.
+```@setup logging
+runtime = round(time() - start_time; digits=2)
+@info "...done after $runtime s."
+```

--- a/docs/src/getting_started.md
+++ b/docs/src/getting_started.md
@@ -1,3 +1,7 @@
+```@setup logging
+@info "Expanding src/getting_started.md..."
+start_time = time()
+```
 # Getting started
 
 To get started with the package we can identify the necessary ingredients to
@@ -278,3 +282,7 @@ Now that we've covered the basics of classical dynamics, we're ready to explore 
 world of nonadiabatic dynamics.
 All the dynamics methods follow these patterns and anything you find elsewhere in the
 documentation should now seem relatively familiar.
+```@setup logging
+runtime = round(time() - start_time; digits=2)
+@info "...done after $runtime s."
+```

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -1,3 +1,7 @@
+```@setup logging
+@info "Expanding src/index.md..."
+start_time = time()
+```
 # Introduction
 
 Welcome to the documentation for NQCDynamics, 
@@ -115,3 +119,7 @@ The first page to read is the [Getting started](@ref) section which walks throug
 needed to perform a conventional classical molecular dynamics simulation.
 After this, the reader is free to explore at their leisure since everything else builds directly
 upon sections from the [Getting started](@ref) page.
+```@setup logging
+runtime = round(time() - start_time; digits=2)
+@info "...done after $runtime s."
+```

--- a/docs/src/initialconditions/ebk.md
+++ b/docs/src/initialconditions/ebk.md
@@ -1,3 +1,7 @@
+```@setup logging
+@info "Expanding src/initialconditions/ebk.md..."
+start_time = time()
+```
 # [Semiclassical EBK quantisation](@id ebk-sampling)
 
 In surface science, it is often of interest to investigate how collisions with surfaces
@@ -94,3 +98,7 @@ procedure, but this technique can use any arbitrary potential.
 In the [hydrogen scattering example](@ref example-h2scattering) we build on this example
 and use the sample procedure to perform scattering simulations starting from this
 distribution.
+```@setup logging
+runtime = round(time() - start_time; digits=2)
+@info "...done after $runtime s."
+```

--- a/docs/src/initialconditions/hamiltonian.md
+++ b/docs/src/initialconditions/hamiltonian.md
@@ -1,3 +1,7 @@
+```@setup logging
+@info "Expanding src/initialconditions/hamiltonian.md..."
+start_time = time()
+```
 # [Thermal Hamiltonian Monte Carlo](@id hmc-sampling)
 
 Our implementation of Hamiltonian Monte Carlo (HMC) is a light wrapper around the
@@ -38,4 +42,8 @@ with the equipartition theorem:
 ```@repl hmc
 Estimators.@estimate potential_energy(sim, chain)
 austrip(sim.temperature) * 3 * 4 / 2
+```
+```@setup logging
+runtime = round(time() - start_time; digits=2)
+@info "...done after $runtime s."
 ```

--- a/docs/src/initialconditions/langevin.md
+++ b/docs/src/initialconditions/langevin.md
@@ -1,4 +1,12 @@
+```@setup logging
+@info "Expanding src/initialconditions/langevin.md..."
+start_time = time()
+```
 # [Thermal Langevin dynamics](@id langevin-sampling)
 
 Thermal initial conditions can be obtained directly from a Langevin dynamics simulations.
 See the [Langevin dynamics page](@ref langevin-dynamics) for more info.
+```@setup logging
+runtime = round(time() - start_time; digits=2)
+@info "...done after $runtime s."
+```

--- a/docs/src/initialconditions/metropolishastings.md
+++ b/docs/src/initialconditions/metropolishastings.md
@@ -1,3 +1,7 @@
+```@setup logging
+@info "Expanding src/initialconditions/metropolishastings.md..."
+start_time = time()
+```
 # [Thermal Metropolis-Hastings Monte Carlo](@id mhmc-sampling)
 
 Metropolis-Hastings Monte Carlo is a popular method for sampling the canonical
@@ -113,3 +117,7 @@ presented in the previous section and `output.R` can be readily passed to provid
 the position distribution.
 The Monte Carlo sampling does not include velocities but these can be readily
 obtained from the Maxwell-Boltzmann distribution.
+```@setup logging
+runtime = round(time() - start_time; digits=2)
+@info "...done after $runtime s."
+```

--- a/docs/src/integration_algorithms.md
+++ b/docs/src/integration_algorithms.md
@@ -1,3 +1,7 @@
+```@setup logging
+@info "Expanding src/integration_algorithms.md..."
+start_time = time()
+```
 # Integration algorithms
 
 At the core of NQCDynamics.jl is the DifferentialEquations.jl package that performs all of the dynamics simulations.
@@ -116,3 +120,7 @@ Using this approach, NQCDynamics.jl implements the BAOAB algorithm for tensorial
     The `DynamicalSDEProblem` was originally implemented for performing Langevin thermostatted dynamics simulations using the BAOAB algorithm.
     At the time of writing, BAOAB is the only algorithm implemented in StochasticDiffEq.jl for these problems.
     In future it would be useful to implement further algorithms and allow for more general noise profiles.
+```@setup logging
+runtime = round(time() - start_time; digits=2)
+@info "...done after $runtime s."
+```

--- a/docs/src/references.md
+++ b/docs/src/references.md
@@ -1,4 +1,12 @@
+```@setup logging
+@info "Expanding src/references.md..."
+start_time = time()
+```
 # References
 
 ```@bibliography
+```
+```@setup logging
+runtime = round(time() - start_time; digits=2)
+@info "...done after $runtime s."
 ```

--- a/docs/src/saving_loading.md
+++ b/docs/src/saving_loading.md
@@ -1,3 +1,7 @@
+```@setup logging
+@info "Expanding src/saving_loading.md..."
+start_time = time()
+```
 # [Saving and loading](@id saving-and-loading)
 
 If you would like to split your workflow into multiple scripts
@@ -49,3 +53,7 @@ model = load("parameters.jld2", "model")
 
 [JLD2](https://github.com/JuliaIO/JLD2.jl) is compatible with any Julia type so it widely
 usable for most of the types you encounter is NQCDynamics.jl and across all Julia packages.
+```@setup logging
+runtime = round(time() - start_time; digits=2)
+@info "...done after $runtime s."
+```


### PR DESCRIPTION
I tried to update the documenter version but the build kept crashing. It turned out this was an error with one of the examples in the `ase.md` file. I've changed this example a little to get it to work.

To help identify this kind of thing in future I've added profiling information to the start and end of each `.md` file. Now we know which part of the docs build is in progress and how long each markdown file takes, this is very useful for #274 as there are a few examples that are taking a long time to run.