### PR TITLE
Update documentation for changes in NQCBase#11

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "NQCDynamics"
 uuid = "36248dfb-79eb-4f4d-ab9c-e29ea5f33e14"
 authors = ["James <james.gardner1421@gmail.com>"]
-version = "0.13.7"
+version = "0.14.0"
 
 [deps]
 AdvancedHMC = "0bf59076-c3b1-5ca4-86bd-e02cd72cde3d"
@@ -62,7 +62,7 @@ MKL_jll = "2023"
 MuladdMacro = "0.2"
 NQCBase = "0.2"
 NQCDistributions = "0.1"
-NQCModels = "0.8"
+NQCModels = "0.9"
 Optim = "1"
 OrdinaryDiffEq = "5, 6"
 Parameters = "0.12"
@@ -106,4 +106,20 @@ Symbolics = "0c5d862f-8b57-4792-8d23-62f2024744c7"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
 [targets]
-test = ["Test", "SafeTestsets", "CSV", "DataFrames", "DiffEqNoiseProcess", "FiniteDiff", "DiffEqDevTools", "Logging", "MKL", "PyCall", "JuLIP", "Symbolics", "Statistics", "Plots", "JLD2"]
+test = [
+    "Test",
+    "SafeTestsets",
+    "CSV",
+    "DataFrames",
+    "DiffEqNoiseProcess",
+    "FiniteDiff",
+    "DiffEqDevTools",
+    "Logging",
+    "MKL",
+    "PyCall",
+    "JuLIP",
+    "Symbolics",
+    "Statistics",
+    "Plots",
+    "JLD2",
+]

--- a/Project.toml
+++ b/Project.toml
@@ -99,7 +99,7 @@ JuLIP = "945c410c-986d-556a-acb1-167a618e0462"
 Logging = "56ddb016-857b-54e1-b83d-db4d58db5568"
 MKL = "33e6dc65-8f57-5167-99aa-e5a354878fb2"
 Plots = "91a5bcdd-55d7-5caf-9e0b-520d859cae80"
-PyCall = "438e738f-606a-5dbb-bf0a-cddfbfd45ab0"
+PythonCall = "6099a3de-0909-46bc-b1f4-468b9a2dfc0d"
 SafeTestsets = "1bc83da4-3b8d-516f-aca4-4fe02f6d838f"
 Statistics = "10745b16-79ce-11e8-11f9-7d13ad32a3b2"
 Symbolics = "0c5d862f-8b57-4792-8d23-62f2024744c7"
@@ -116,7 +116,7 @@ test = [
     "DiffEqDevTools",
     "Logging",
     "MKL",
-    "PyCall",
+    "PythonCall",
     "JuLIP",
     "Symbolics",
     "Statistics",

--- a/test/Analysis/diatomic.jl
+++ b/test/Analysis/diatomic.jl
@@ -1,7 +1,7 @@
 using Test
 using NQCDynamics
 using Unitful, UnitfulAtomic
-using PyCall
+using PythonCall
 using NQCModels
 using JLD2
 


### PR DESCRIPTION
Removed ASEConvert.jl example since it includes unnecessary extra steps since James implemented the ase conversion functions. 
Replaced with an example for how to use PythonCall.jl to create an ase atoms object and how to convert it instead. 