### PR TITLE
Moved general surface hopping functions to SurfaceHoppingMethods.jl

### DIFF
--- a/src/DynamicsMethods/SurfaceHoppingMethods/SurfaceHoppingMethods.jl
+++ b/src/DynamicsMethods/SurfaceHoppingMethods/SurfaceHoppingMethods.jl
@@ -93,6 +93,22 @@ function DynamicsUtils.get_hopping_eigenvalues(sim::RingPolymerSimulation, r::Ab
     return Calculators.get_centroid_eigen(sim.calculator, r).values
 end
 
+function DynamicsUtils.get_hopping_nonadiabatic_coupling(sim::Simulation, r::AbstractMatrix)
+    return Calculators.get_nonadiabatic_coupling(sim.calculator, r)
+end
+
+function DynamicsUtils.get_hopping_nonadiabatic_coupling(sim::RingPolymerSimulation, r::AbstractArray{T,3}) where {T}
+    return Calculators.get_centroid_nonadiabatic_coupling(sim.calculator, r)
+end
+
+function DynamicsUtils.get_hopping_velocity(::Simulation, v::AbstractMatrix)
+    return v
+end
+
+function DynamicsUtils.get_hopping_velocity(::RingPolymerSimulation, v::AbstractArray{T,3}) where {T}
+    return get_centroid(v)
+end
+
 include("decoherence_corrections.jl")
 include("surface_hopping.jl")
 include("fssh.jl")

--- a/src/DynamicsMethods/SurfaceHoppingMethods/fssh.jl
+++ b/src/DynamicsMethods/SurfaceHoppingMethods/fssh.jl
@@ -75,14 +75,6 @@ function evaluate_hopping_probability!(sim::AbstractSimulation{<:FSSH}, u, dt)
     fewest_switches_probability!(sim.method.hopping_probability, v, σ, s, d, dt)
 end
 
-function DynamicsUtils.get_hopping_nonadiabatic_coupling(sim::Simulation, r::AbstractMatrix)
-    return Calculators.get_nonadiabatic_coupling(sim.calculator, r)
-end
-
-function DynamicsUtils.get_hopping_velocity(::Simulation, v::AbstractMatrix)
-    return v
-end
-
 function fewest_switches_probability!(probability, v, σ, s, d, dt)
     probability .= 0 # Set all entries to 0
     for m in axes(σ, 1)

--- a/src/DynamicsMethods/SurfaceHoppingMethods/rpsh.jl
+++ b/src/DynamicsMethods/SurfaceHoppingMethods/rpsh.jl
@@ -27,14 +27,6 @@ function DynamicsMethods.motion!(du, u, sim::RingPolymerSimulation{<:SurfaceHopp
     DynamicsUtils.set_quantum_derivative!(dσ, u, sim)
 end
 
-function DynamicsUtils.get_hopping_nonadiabatic_coupling(sim::RingPolymerSimulation, r::AbstractArray{T,3}) where {T}
-    return Calculators.get_centroid_nonadiabatic_coupling(sim.calculator, r)
-end
-
-function DynamicsUtils.get_hopping_velocity(::RingPolymerSimulation, v::AbstractArray{T,3}) where {T}
-    return get_centroid(v)
-end
-
 function perform_rescaling!(
     sim::RingPolymerSimulation{<:SurfaceHopping}, velocity, γ, d
 )


### PR DESCRIPTION
Moved two generally applicable surface hopping functions get_hopping_nonadiabatic_coupling() and get_hopping_velocity() to SurfaceHoppingMethods.jl and moved their duplicate RingPolymer definitions to the same file to bring these definitions more in line with the duplicate function definition philosophy in the rest of NQCD