### PR TITLE
Moving general surface hopping functions to SurfaceHoppingMethods.jl

### DIFF
--- a/src/DynamicsMethods/SurfaceHoppingMethods/SurfaceHoppingMethods.jl
+++ b/src/DynamicsMethods/SurfaceHoppingMethods/SurfaceHoppingMethods.jl
@@ -84,6 +84,14 @@ function DynamicsMethods.create_problem(u0, tspan, sim::AbstractSimulation{<:Sur
         callback=DynamicsMethods.get_callbacks(sim))
 end
 
+function DynamicsUtils.get_hopping_eigenvalues(sim::Simulation, r::AbstractMatrix)
+    return Calculators.get_eigen(sim.calculator, r).values
+end
+
+function DynamicsUtils.get_hopping_nonadiabatic_coupling(sim::RingPolymerSimulation, r::AbstractArray{T,3}) where {T}
+    return Calculators.get_centroid_nonadiabatic_coupling(sim.calculator, r)
+end
+
 include("decoherence_corrections.jl")
 include("surface_hopping.jl")
 include("fssh.jl")

--- a/src/DynamicsMethods/SurfaceHoppingMethods/SurfaceHoppingMethods.jl
+++ b/src/DynamicsMethods/SurfaceHoppingMethods/SurfaceHoppingMethods.jl
@@ -93,6 +93,22 @@ function DynamicsUtils.get_hopping_eigenvalues(sim::RingPolymerSimulation, r::Ab
     return Calculators.get_centroid_eigen(sim.calculator, r).values
 end
 
+function DynamicsUtils.get_hopping_nonadiabatic_coupling(sim::Simulation, r::AbstractMatrix)
+    return Calculators.get_nonadiabatic_coupling(sim.calculator, r)
+end
+
+function DynamicsUtils.get_hopping_nonadiabatic_coupling(sim::RingPolymerSimulation, r::AbstractArray{T,3}) where {T}
+    return Calculators.get_centroid_nonadiabatic_coupling(sim.calculator, r)
+end
+
+function DynamicsUtils.get_hopping_velocity(::Simulation, v::AbstractMatrix)
+    return v
+end
+
+function DynamicsUtils.get_hopping_velocity(::RingPolymerSimulation, v::AbstractArray{T,3}) where {T}
+    return get_centroid(v)
+end
+
 include("decoherence_corrections.jl")
 include("surface_hopping.jl")
 include("fssh.jl")

--- a/src/DynamicsMethods/SurfaceHoppingMethods/SurfaceHoppingMethods.jl
+++ b/src/DynamicsMethods/SurfaceHoppingMethods/SurfaceHoppingMethods.jl
@@ -16,6 +16,7 @@ using NQCDynamics:
     NQCDynamics,
     AbstractSimulation,
     Simulation,
+    RingPolymerSimulation,
     Calculators,
     DynamicsMethods,
     DynamicsUtils,

--- a/src/DynamicsMethods/SurfaceHoppingMethods/SurfaceHoppingMethods.jl
+++ b/src/DynamicsMethods/SurfaceHoppingMethods/SurfaceHoppingMethods.jl
@@ -11,6 +11,7 @@ using ComponentArrays: ComponentVector
 using DiffEqBase: DiffEqBase
 using LinearAlgebra: LinearAlgebra, lmul!
 using OrdinaryDiffEq: OrdinaryDiffEq
+using RingPolymerArrays: get_centroid
 
 using NQCDynamics:
     NQCDynamics,

--- a/src/DynamicsMethods/SurfaceHoppingMethods/SurfaceHoppingMethods.jl
+++ b/src/DynamicsMethods/SurfaceHoppingMethods/SurfaceHoppingMethods.jl
@@ -88,8 +88,8 @@ function DynamicsUtils.get_hopping_eigenvalues(sim::Simulation, r::AbstractMatri
     return Calculators.get_eigen(sim.calculator, r).values
 end
 
-function DynamicsUtils.get_hopping_nonadiabatic_coupling(sim::RingPolymerSimulation, r::AbstractArray{T,3}) where {T}
-    return Calculators.get_centroid_nonadiabatic_coupling(sim.calculator, r)
+function DynamicsUtils.get_hopping_eigenvalues(sim::RingPolymerSimulation, r::AbstractArray{T,3}) where {T}
+    return Calculators.get_centroid_eigen(sim.calculator, r).values
 end
 
 include("decoherence_corrections.jl")

--- a/src/DynamicsMethods/SurfaceHoppingMethods/fssh.jl
+++ b/src/DynamicsMethods/SurfaceHoppingMethods/fssh.jl
@@ -83,10 +83,6 @@ function DynamicsUtils.get_hopping_velocity(::Simulation, v::AbstractMatrix)
     return v
 end
 
-function DynamicsUtils.get_hopping_eigenvalues(sim::Simulation, r::AbstractMatrix)
-    return Calculators.get_eigen(sim.calculator, r).values
-end
-
 function fewest_switches_probability!(probability, v, σ, s, d, dt)
     probability .= 0 # Set all entries to 0
     for m in axes(σ, 1)

--- a/src/DynamicsMethods/SurfaceHoppingMethods/fssh.jl
+++ b/src/DynamicsMethods/SurfaceHoppingMethods/fssh.jl
@@ -75,14 +75,6 @@ function evaluate_hopping_probability!(sim::AbstractSimulation{<:FSSH}, u, dt)
     fewest_switches_probability!(sim.method.hopping_probability, v, σ, s, d, dt)
 end
 
-function DynamicsUtils.get_hopping_nonadiabatic_coupling(sim::Simulation, r::AbstractMatrix)
-    return Calculators.get_nonadiabatic_coupling(sim.calculator, r)
-end
-
-function DynamicsUtils.get_hopping_velocity(::Simulation, v::AbstractMatrix)
-    return v
-end
-
 function fewest_switches_probability!(probability, v, σ, s, d, dt)
     probability .= 0 # Set all entries to 0
     for m in axes(σ, 1)

--- a/src/DynamicsMethods/SurfaceHoppingMethods/rpsh.jl
+++ b/src/DynamicsMethods/SurfaceHoppingMethods/rpsh.jl
@@ -27,14 +27,6 @@ function DynamicsMethods.motion!(du, u, sim::RingPolymerSimulation{<:SurfaceHopp
     DynamicsUtils.set_quantum_derivative!(dσ, u, sim)
 end
 
-function DynamicsUtils.get_hopping_nonadiabatic_coupling(sim::RingPolymerSimulation, r::AbstractArray{T,3}) where {T}
-    return Calculators.get_centroid_nonadiabatic_coupling(sim.calculator, r)
-end
-
-function DynamicsUtils.get_hopping_velocity(::RingPolymerSimulation, v::AbstractArray{T,3}) where {T}
-    return get_centroid(v)
-end
-
 function perform_rescaling!(
     sim::RingPolymerSimulation{<:SurfaceHopping}, velocity, γ, d
 )

--- a/src/DynamicsMethods/SurfaceHoppingMethods/rpsh.jl
+++ b/src/DynamicsMethods/SurfaceHoppingMethods/rpsh.jl
@@ -27,12 +27,12 @@ function DynamicsMethods.motion!(du, u, sim::RingPolymerSimulation{<:SurfaceHopp
     DynamicsUtils.set_quantum_derivative!(dσ, u, sim)
 end
 
-function DynamicsUtils.get_hopping_velocity(::RingPolymerSimulation, v::AbstractArray{T,3}) where {T}
-    return get_centroid(v)
+function DynamicsUtils.get_hopping_nonadiabatic_coupling(sim::RingPolymerSimulation, r::AbstractArray{T,3}) where {T}
+    return Calculators.get_centroid_nonadiabatic_coupling(sim.calculator, r)
 end
 
-function DynamicsUtils.get_hopping_eigenvalues(sim::RingPolymerSimulation, r::AbstractArray{T,3}) where {T}
-    return Calculators.get_centroid_eigen(sim.calculator, r).values
+function DynamicsUtils.get_hopping_velocity(::RingPolymerSimulation, v::AbstractArray{T,3}) where {T}
+    return get_centroid(v)
 end
 
 function perform_rescaling!(

--- a/src/DynamicsMethods/SurfaceHoppingMethods/rpsh.jl
+++ b/src/DynamicsMethods/SurfaceHoppingMethods/rpsh.jl
@@ -27,10 +27,6 @@ function DynamicsMethods.motion!(du, u, sim::RingPolymerSimulation{<:SurfaceHopp
     DynamicsUtils.set_quantum_derivative!(dσ, u, sim)
 end
 
-function DynamicsUtils.get_hopping_nonadiabatic_coupling(sim::RingPolymerSimulation, r::AbstractArray{T,3}) where {T}
-    return Calculators.get_centroid_nonadiabatic_coupling(sim.calculator, r)
-end
-
 function DynamicsUtils.get_hopping_velocity(::RingPolymerSimulation, v::AbstractArray{T,3}) where {T}
     return get_centroid(v)
 end


### PR DESCRIPTION
Moved get_hopping_velocity() and get_hopping_nonadiabatic_couplings() out of fssh.jl and into SurfaceHoppingMethods.jl. I have also moved their duplicate definitions for RingPolymerSimulations into the same file to bring these definitions inline with the philosophy for duplicate definitions used elsewhere in the code.