### PR TITLE
Fix CI and rename Temperature to TemperatureSetting

### DIFF
--- a/docs/src/NQCModels/combining_models.md
+++ b/docs/src/NQCModels/combining_models.md
@@ -19,7 +19,7 @@ For example, in order to run [Molecular Dynamics with Electronic friction](@ref 
 However, most models for potential energy surfaces only provide `potential` and `derivative`, whereas `friction!` is provided by an `ElectronicFrictionProvider`. 
 
 To combine different models together for a system, we can use [`Subsystem`](@ref)s to define which atoms in the system a given model should be applied to, and a [`CompositeModel`](@ref) to combine the different models into one. 
-If different [`Subsystem`](@ref)s should experience different effective temperatures, a [`Thermostat`](@ref) can be provided when initialising a [`Simulation`](@ref). 
+If different [`Subsystem`](@ref)s should experience different effective temperatures, a [`TemperatureSetting`](@ref) can be provided when initialising a [`Simulation`](@ref). 
 
 ![An overview of the different components used to combine models in NQCModels.jl](../assets/compositemodels/struct-explainer.svg)
 

--- a/docs/src/dynamicssimulations/dynamicssimulations.md
+++ b/docs/src/dynamicssimulations/dynamicssimulations.md
@@ -49,7 +49,7 @@ For time-dependent temperatures, the temperature can be set to a function. This 
 
 **Different temperatures per atom**
 
-If different parts of the simulated system should be affected by different effective temperatures, a `Vector` of [`Temperature`](@ref)s can be passed as the temperature argument. 
+If different parts of the simulated system should be affected by different effective temperatures, a `Vector` of [`TemperatureSetting`](@ref)s can be passed as the temperature argument. 
 However, only one temperature should be applied to each atom in the system. 
 
 ### DynamicsVariables

--- a/docs/src/examples/mdef_multithermostat.md
+++ b/docs/src/examples/mdef_multithermostat.md
@@ -181,11 +181,11 @@ combined_model = CompositeModel(
 	phononic_friction
 )
 
-# Create Temperature objects to apply T_el to adsorbates, T_ph to surface
+# Create TemperatureSetting objects to apply T_el to adsorbates, T_ph to surface
 # Manually specified indices
-electron_thermostat = Temperature(T_el_function, indices = [55,56]) 
+electron_thermostat = TemperatureSetting(T_el_function, indices = [55,56]) 
 # Inherit indices from a Subsystem
-phonon_thermostat = Temperature(T_ph_function, phononic_friction) 
+phonon_thermostat = TemperatureSetting(T_ph_function, phononic_friction) 
 
 sim_T_el_only = Simulation{MDEF}(
 	atoms, 

--- a/src/NQCDynamics.jl
+++ b/src/NQCDynamics.jl
@@ -18,7 +18,7 @@ export Simulation,
        RingPolymerSimulation,
        natoms,
        masses,
-       Thermostat,
+       TemperatureSetting,
        get_temperature
 
 @reexport using NQCDistributions

--- a/test/Core/simulations.jl
+++ b/test/Core/simulations.jl
@@ -24,17 +24,17 @@ model = NQCModels.Free()
 
 @testset "Thermostats" begin
     # Init thermostat with Unitful quantity
-    thermostat1=Thermostat(10u"K", [1,2])
+    thermostat1=TemperatureSetting(10u"K", [1,2])
     @test NQCDynamics.get_temperature(thermostat1, 0) == NQCDynamics.get_temperature(thermostat1, 100)
     # Init thermostat with function
-    thermostat2=Thermostat(x->(10+x*u"fs^-1")*u"K", [2,3])
+    thermostat2=TemperatureSetting(x->(10+x*u"fs^-1")*u"K", [2,3])
     @test NQCDynamics.get_temperature(thermostat2) == austrip(10u"K")
     @test NQCDynamics.get_temperature(thermostat2, 10u"fs") == austrip(20u"K")
     # Test that thermostats with overlapping indices throw an error
     @test_throws DomainError Simulation(atoms, model; temperature=[thermostat1, thermostat2])
     # Test system size / total thermostat size mismatch
     @test_throws DomainError Simulation(Atoms([:N, :H, :H, :H,]), model; temperature=thermostat1)
-    thermostat3=thermostat2=Thermostat(x->(10+x*u"fs^-1")*u"K", [3,4])
+    thermostat3=thermostat2=TemperatureSetting(x->(10+x*u"fs^-1")*u"K", [3,4])
     # Combined temperature evaluation
     sim = Simulation(Atoms([:N, :H, :H, :H,]), model; temperature=[thermostat1, thermostat3])
     @test NQCDynamics.get_temperature(sim, austrip(1u"fs")) == austrip.([10u"K", 10u"K", 11u"K", 11u"K"])


### PR DESCRIPTION
This was necessary as “Thermostat” is technically incorrect, and “Temperature” is already taken by Unitful, which is often imported along with NQCDynamics.

I also managed to accidentally nuke the CI tests by forgetting to rename `Thermostat` to `Temperature` everywhere, but this time it should work. 