### PR TITLE
Benchmark most recent release of NQCDynamics

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -24,7 +24,17 @@ jobs:
       fail-fast: false
 
     steps:
-      - uses: actions/checkout@v3
+      - id: workspace
+        run: echo $GITHUB_WORKSPACE
+      - uses: actions/checkout@v4
+        with:
+          fetch-tags: true
+          fetch-depth: 0
+      - id: save_tag
+        run: |
+          echo "$(pwd)"
+          echo "current_version=$(git describe --tags --abbrev=0)" >> "$GITHUB_OUTPUT"
+          echo "last_version=$(git for-each-ref --sort=-taggerdate --format '%(tag)' refs/tags | sed -n 2p)" >> "$GITHUB_OUTPUT"
       - uses: julia-actions/setup-julia@latest
 
       - uses: actions/cache@v3
@@ -46,15 +56,108 @@ jobs:
       - name: Add ACEregistry
         run: julia -e 'using Pkg; Pkg.Registry.add(RegistrySpec(url="https://github.com/ACEsuit/ACEregistry"))'
         shell: bash
+      - name: Make benchmark directory
+        run: |
+          mkdir -p /home/runner/NQCDynamics.jl/NQCDynamics.jl/benchmarks
+        shell: bash
 
       - name: Install ase for IO tests
         run: pip3 install ase
-
       - uses: julia-actions/julia-buildpkg@v1
       - uses: julia-actions/julia-runtest@v1
         env:
           GROUP: ${{ matrix.group }}
+          BENCHMARK_OUTPUT_DIR: /home/runner/NQCDynamics.jl/NQCDynamics.jl/benchmarks
       - uses: julia-actions/julia-processcoverage@v1
       - uses: codecov/codecov-action@v3
         with:
           file: lcov.info
+      - name: 'Upload Artifact'
+        uses: actions/upload-artifact@v4
+        with:
+          name: ${{ matrix.group }}-timings
+          path: /home/runner/NQCDynamics.jl/NQCDynamics.jl/benchmarks/*.json
+          retention-days: 21
+  upload_benchmarks:
+    runs-on: ubuntu-latest
+    needs: [test]
+    if: ${{ always() }}
+    outputs:
+      newest_release_version: ${{ steps.save_tag.current_version }}
+      previous_release_version: ${{ steps.save_tag.last_version }}
+    steps: 
+      # Now we're in /home/runner/NQCDynamics.jl/NQCDynamics.jl
+      - uses: actions/checkout@v4
+        with:
+          fetch-tags: true
+          fetch-depth: 0
+          ref: performance-tracking
+      - id: save_tag
+        run: |
+          echo "$(pwd)"
+          echo "current_version=$(git tag --list --sort=-taggerdate | sed -n 1p)" >> "$GITHUB_OUTPUT"
+          echo "CURRENT_VERSION=$(git tag --list --sort=-taggerdate | sed -n 1p)" >> "$GITHUB_ENV"
+          echo "last_version=$(git tag --list --sort=-taggerdate | sed -n 2p)" >> "$GITHUB_OUTPUT"
+          echo "LAST_VERSION=$(git tag --sort=-taggerdate | sed -n 2p)" >> "$GITHUB_ENV"
+      - uses: julia-actions/setup-julia@latest
+      - name: Download any artifacts from test steps
+        uses: actions/download-artifact@v4
+        with:
+          path: benchmarks
+          pattern: '*-timings'
+          merge-multiple: true
+      - run: ls -l /home/runner/work/NQCDynamics.jl/NQCDynamics.jl/benchmarks/
+      - uses: julia-actions/setup-julia@latest
+      - name: Initialise Julia environment
+        run: |
+          mkdir -p /home/runner/work/NQCDynamics.jl/NQCDynamics.jl/benchmark-graphics
+          julia -e 'using Pkg; Pkg.activate("."); Pkg.instantiate()'
+      - name: Update Benchmark repo (Commit)
+        if: ${{ github.event_name != 'release' }}
+        run: |
+          export BENCHMARK_REPO=$(pwd)
+          mkdir -p NQCDynamics.jl/commits/$NEW_VERSION
+          mv /home/runner/work/NQCDynamics.jl/NQCDynamics.jl/benchmarks/*.json /home/runner/work/NQCDynamics.jl/NQCDynamics.jl/NQCDynamics.jl/commits/$NEW_VERSION/
+          # Generate benchmark time comparison graphics
+          julia --project=. benchmark_plots.jl
+          # Note: the following account information will not work on GHES
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git add /home/runner/work/NQCDynamics.jl/NQCDynamics.jl/NQCDynamics.jl/commits/$NEW_VERSION/*.json
+          git commit -m "Stored test performance"
+          git push
+        env:
+          NEW_VERSION: ${{ github.sha }}
+          GRAPHICS_PATH: benchmark-graphics
+      - name: Update Benchmark repo (Release)
+        if: ${{ github.event_name == 'release' }}
+        run: |
+          export NEW_VERSION=$CURRENT_VERSION
+          export CURRENT_VERSION=$LAST_VERSION
+          cd $GITHUB_WORKSPACE/performance-tracking
+          export BENCHMARK_REPO=$(pwd)
+          date > generated.txt
+          mkdir -p NQCDynamics.jl/tags/$VERSION
+          mv /home/runner/work/NQCDynamics.jl/NQCDynamics.jl/benchmarks/*.json /home/runner/work/NQCDynamics.jl/NQCDynamics.jl/NQCDynamics.jl/tags/$NEW_VERSION/
+          # Generate benchmark time comparison graphics
+          julia --project=. benchmark_plots.jl
+          # Note: the following account information will not work on GHES
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git add /home/runner/work/NQCDynamics.jl/NQCDynamics.jl/NQCDynamics.jl/tags/$VERSION/*.json
+          git commit -m "Stored test performance"
+          git push
+        env:
+          GRAPHICS_PATH: benchmark-graphics
+      - id: upload-artifact
+        uses: actions/upload-artifact@v4
+        with:
+          path: benchmark-graphics/*.png
+          name: Benchmark version comparison
+          retention-days: 21
+      - id: post
+        run: |
+          echo "### Unit test benchmark :rocket:" >> "$GITHUB_STEP_SUMMARY"
+          echo "Compared dynamics test timings between ${{ steps.save_tag.outputs.newest_release_version }} and ${{ github.sha }}." >> "$GITHUB_STEP_SUMMARY"
+          echo "Download the results [here](${{ steps.upload-artifact.outputs.artifact-url }})" >> "$GITHUB_STEP_SUMMARY"
+

--- a/Project.toml
+++ b/Project.toml
@@ -94,12 +94,14 @@ UnitfulAtomic = "1"
 julia = "≥1.9"
 
 [extras]
+CairoMakie = "13f3f980-e62b-5c42-98c6-ff1f3baf88f0"
 CSV = "336ed68f-0bac-5ca0-87d4-7b16caf5d00b"
 DataFrames = "a93c6f00-e57d-5684-b7b6-d8193f3e46c0"
 DiffEqDevTools = "f3b72e0c-5b89-59e1-b016-84e28bfd966d"
 DiffEqNoiseProcess = "77a26b50-5914-5dd7-bc55-306e6241c503"
 FiniteDiff = "6a86dc24-6348-571c-b903-95158fe2bd41"
 JLD2 = "033835bb-8acc-5ee8-8aae-3f567f8a3819"
+JSON = "682c06a0-de6a-54ab-a142-c8b1cf79cde6"
 JuLIP = "945c410c-986d-556a-acb1-167a618e0462"
 Logging = "56ddb016-857b-54e1-b83d-db4d58db5568"
 MKL = "33e6dc65-8f57-5167-99aa-e5a354878fb2"
@@ -111,4 +113,4 @@ Symbolics = "0c5d862f-8b57-4792-8d23-62f2024744c7"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
 [targets]
-test = ["Test", "SafeTestsets", "CSV", "DataFrames", "DiffEqNoiseProcess", "FiniteDiff", "DiffEqDevTools", "Logging", "MKL", "PythonCall", "JuLIP", "Symbolics", "Statistics", "Plots", "JLD2"]
+test = ["Test", "SafeTestsets", "CSV", "DataFrames", "DiffEqNoiseProcess", "FiniteDiff", "DiffEqDevTools", "Logging", "MKL", "PythonCall", "JuLIP", "Symbolics", "Statistics", "CairoMakie", "JLD2", "JSON"]

--- a/test/Dynamics/bcbwithtsit5.jl
+++ b/test/Dynamics/bcbwithtsit5.jl
@@ -2,16 +2,23 @@ using Test
 using NQCDynamics
 using OrdinaryDiffEq: Tsit5
 using Random: seed!
+import JSON
+
+benchmark_dir = get(ENV, "BENCHMARK_OUTPUT_DIR", "/tmp/nqcd_benchmark")
+benchmark_results = Dict{String, Any}("title_for_plotting" => "BCBwithTsit5 Tests")
 
 @testset "Ehrenfest" begin
     sim = RingPolymerSimulation{Ehrenfest}(Atoms(2000), TullyModelOne(), 10; temperature=1e-3)
     u = DynamicsVariables(sim, fill(10/2000, size(sim)), fill(-5, size(sim)) .+ randn(size(sim)), PureState(1))
     dt = 0.1
-
-    sol = run_dynamics(sim, (0, 2000.0), u; output=OutputDynamicsVariables, algorithm=DynamicsMethods.IntegrationAlgorithms.BCBwithTsit5(Tsit5()), saveat=0:10:2000, dt=dt)
+    
+    dyn_test = @timed run_dynamics(sim, (0, 2000.0), u; output=OutputDynamicsVariables, algorithm=DynamicsMethods.IntegrationAlgorithms.BCBwithTsit5(Tsit5()), saveat=0:10:2000, dt=dt)
+    sol = dyn_test.value
+    
     sol1 = run_dynamics(sim, (0, 2000.0), u; output=OutputDynamicsVariables, algorithm=Tsit5(), saveat=0:10:2000, abstol=1e-6, reltol=1e-6)
 
     @test sol[:OutputDynamicsVariables] ≈ sol1[:OutputDynamicsVariables] rtol=1e-3
+    benchmark_results["Ehrenfest"] = Dict("Time" => dyn_test.time, "Allocs" => dyn_test.bytes)
 end
 
 @testset "FSSH" begin
@@ -20,9 +27,16 @@ end
     dt = 0.1
 
     seed!(1)
-    sol = run_dynamics(sim, (0, 2000.0), u; output=OutputDynamicsVariables, algorithm=DynamicsMethods.IntegrationAlgorithms.BCBwithTsit5(Tsit5()), saveat=0:10:2000, dt=dt)
+    dyn_test = @timed run_dynamics(sim, (0, 2000.0), u; output=OutputDynamicsVariables, algorithm=DynamicsMethods.IntegrationAlgorithms.BCBwithTsit5(Tsit5()), saveat=0:10:2000, dt=dt)
+    sol = dyn_test.value
     seed!(1)
     sol1 = run_dynamics(sim, (0, 2000.0), u; output=OutputDynamicsVariables, algorithm=Tsit5(), saveat=0:10:2000, dt=dt, adaptive=false)
 
     @test sol[:OutputDynamicsVariables] ≈ sol1[:OutputDynamicsVariables] rtol=1e-3
+    benchmark_results["FSSH"] = Dict("Time" => dyn_test.time, "Allocs" => dyn_test.bytes)
 end
+
+# Output benchmarking dict
+output_file = open("$(benchmark_dir)/BCBwithTsit5.json", "w")
+JSON.print(output_file, benchmark_results)
+close(output_file)

--- a/test/Dynamics/classical.jl
+++ b/test/Dynamics/classical.jl
@@ -2,11 +2,15 @@ using NQCDynamics
 using Test
 using Unitful
 using ComponentArrays
+import JSON
 
 include("utils.jl")
 
 atoms = Atoms([:H])
 model = NQCModels.Harmonic()
+
+benchmark_dir = get(ENV, "BENCHMARK_OUTPUT_DIR", "/tmp/nqcd_benchmark")
+benchmark_results = Dict{String, Any}("title_for_plotting" => "Classical Tests")
 
 @testset "Classical" begin
     sim = Simulation{Classical}(atoms, model)
@@ -19,8 +23,10 @@ model = NQCModels.Harmonic()
     r = get_blank(sim)
     u0 = ComponentVector(v=v, r=r)
 
-    sol = run_dynamics(sim, (0.0, 1000.0), u0; dt=0.1, output=(OutputTotalEnergy))
+    dyn_test = @timed run_dynamics(sim, (0.0, 1000.0), u0; dt=0.1, output=(OutputTotalEnergy))
+    sol = dyn_test.value
     @test sol[:OutputTotalEnergy][1] ≈ sol[:OutputTotalEnergy][end] rtol=1e-2
+    benchmark_results["Classical"] = Dict("Time" => dyn_test.time, "Allocs" => dyn_test.bytes)
 end
 
 @testset "Ring polymer classical" begin
@@ -34,8 +40,10 @@ end
     r = get_blank(sim)
     u0 = ComponentVector(v=v, r=r)
 
-    sol = run_dynamics(sim, (0.0, 1000.0), u0; dt=0.1, output=(OutputTotalEnergy))
+    dyn_test = @timed run_dynamics(sim, (0.0, 1000.0), u0; dt=0.1, output=(OutputTotalEnergy))
+    sol = dyn_test.value
     @test sol[:OutputTotalEnergy][1] ≈ sol[:OutputTotalEnergy][end] rtol=1e-2
+    benchmark_results["Ring Polymer Classical"] = Dict("Time" => dyn_test.time, "Allocs" => dyn_test.bytes)
 end
 
 @testset "Fermion model classical adiabatic dynamics" begin
@@ -44,8 +52,10 @@ end
     v = rand(VelocityBoltzmann(300u"K", atoms.masses, size(sim)))
     r = [model.model.morse.x₀;;]
     u0 = DynamicsVariables(sim, v, r)
-    sol = run_dynamics(sim, (0.0, 900.0u"fs"), u0; dt=1u"fs", output=(OutputTotalEnergy))
+    dyn_test = @timed run_dynamics(sim, (0.0, 900.0u"fs"), u0; dt=1u"fs", output=(OutputTotalEnergy))
+    sol = dyn_test.value
     @test sol[:OutputTotalEnergy][1] ≈ sol[:OutputTotalEnergy][end] rtol=1e-2
+    benchmark_results["Fermion model classical adiabatic dynamics"] = Dict("Time" => dyn_test.time, "Allocs" => dyn_test.bytes)
 end
 
 @testset "Fermion model ring polymer adiabatic dynamics" begin
@@ -56,6 +66,14 @@ end
     r = model.model.morse.x₀
     d = DynamicalDistribution(v, r, size(sim))
     u0 = rand(d)
-    sol = run_dynamics(sim, (0.0, 900.0u"fs"), u0; dt=1u"fs", output=(OutputTotalEnergy))
+    dyn_test = @timed run_dynamics(sim, (0.0, 900.0u"fs"), u0; dt=1u"fs", output=(OutputTotalEnergy))
+    sol = dyn_test.value
     @test sol[:OutputTotalEnergy][1] ≈ sol[:OutputTotalEnergy][end] rtol=1e-2
+    benchmark_results["Fermion model ring polymer adiabatic dynamics"] = Dict("Time" => dyn_test.time, "Allocs" => dyn_test.bytes)
 end
+
+# Output benchmarking dict
+output_file = open("$(benchmark_dir)/classical.json", "w")
+JSON.print(output_file, benchmark_results)
+close(output_file)
+

--- a/test/Dynamics/diabatic_mdef.jl
+++ b/test/Dynamics/diabatic_mdef.jl
@@ -1,6 +1,10 @@
 using Test
 using NQCDynamics
 using Unitful, UnitfulAtomic
+import JSON
+
+benchmark_dir = get(ENV, "BENCHMARK_OUTPUT_DIR", "/tmp/nqcd_benchmark")
+benchmark_results = Dict{String, Any}("title_for_plotting" => "DiabaticMDEF Tests")
 
 atoms = Atoms(1u"u")
 nstates = 100
@@ -38,12 +42,21 @@ end
 @testset "Simulation{DiabaticMDEF}" begin
     sim = Simulation{DiabaticMDEF}(atoms, model; temperature=T, friction_method=ClassicalMethods.WideBandExact(model.ρ, 1/T))
     u = DynamicsVariables(sim, rand(1,1), rand(1,1))
-    run_dynamics(sim, (0.0, 1.0), u; dt=0.1, output=OutputDynamicsVariables)
+    dyn_test = @timed run_dynamics(sim, (0.0, 1.0), u; dt=0.1, output=OutputDynamicsVariables)
+    sol = dyn_test.value
+    benchmark_results["Simulation{DiabaticMDEF}"] = Dict("Time" => dyn_test.time, "Allocs" => dyn_test.bytes)
 end
 
 @testset "RingPolymerSimulation{DiabaticMDEF}" begin
     n_beads = 10
     sim = RingPolymerSimulation{DiabaticMDEF}(atoms, model, n_beads; temperature=T, friction_method=ClassicalMethods.WideBandExact(model.ρ, 1/T))
     u = DynamicsVariables(sim, rand(1,1,n_beads), rand(1,1,n_beads))
-    run_dynamics(sim, (0.0, 1.0), u; dt=0.1, output=OutputDynamicsVariables)
+    dyn_test = @timed run_dynamics(sim, (0.0, 1.0), u; dt=0.1, output=OutputDynamicsVariables)
+    sol = dyn_test.value
+    benchmark_results["RingPolymerSimulation{DiabaticMDEF}"] = Dict("Time" => dyn_test.time, "Allocs" => dyn_test.bytes)
 end
+
+# Output benchmarking dict
+output_file = open("$(benchmark_dir)/diabaticMDEF.json", "w")
+JSON.print(output_file, benchmark_results)
+close(output_file)

--- a/test/Dynamics/ehrenfest.jl
+++ b/test/Dynamics/ehrenfest.jl
@@ -6,6 +6,10 @@ using OrdinaryDiffEq
 using Statistics: var
 using DataFrames, CSV
 using Interpolations
+import JSON
+
+benchmark_dir = get(ENV, "BENCHMARK_OUTPUT_DIR", "/tmp/nqcd_benchmark")
+benchmark_results = Dict{String, Any}("title_for_plotting" => "Ehrenfest Tests")
 
 @test Ehrenfest{Float64}(2) isa Ehrenfest
 atoms = Atoms(:H)
@@ -46,12 +50,16 @@ atoms = Atoms(:H)
 
         dt = 2e-3
         u = DynamicsVariables(sim, v, r, PureState(1, Adiabatic()))
-        traj1 = run_dynamics(sim, (0.0, 50.0), u; output, dt)
+        dyn_test = @timed run_dynamics(sim, (0.0, 50.0), u; output, dt)
+        traj1 = dyn_test.value
         @test isapprox(var(traj1[:OutputTotalEnergy]), 0; atol=1e-6)
+        benchmark_results["TullyModelTwo"] = Dict("Time" => dyn_test.time, "Allocs" => dyn_test.bytes)
 
         u = DynamicsVariables(sim, v, r, PureState(1, Adiabatic()))
-        traj2 = run_dynamics(sim, (0.0, 50.0), u; algorithm=Feagin12(), output, reltol=1e-15, abstol=1e-15, saveat=dt)
+        dyn_test = @timed run_dynamics(sim, (0.0, 50.0), u; algorithm=Feagin12(), output, reltol=1e-15, abstol=1e-15, saveat=dt)
+        traj2 = dyn_test.value
         @test isapprox(var(traj2[:OutputTotalEnergy]), 0; atol=1e-6)
+        benchmark_results["TullyModelTwo Feagin12"] = Dict("Time" => dyn_test.time, "Allocs" => dyn_test.bytes)
 
         @test traj1[:OutputKineticEnergy] ≈ traj2[:OutputKineticEnergy] rtol = 1e-3
         @test traj1[:OutputPotentialEnergy] ≈ traj2[:OutputPotentialEnergy] rtol = 1e-1
@@ -78,12 +86,18 @@ atoms = Atoms(:H)
         tspan = (0.0, 2000.0)
         dt = 10.0
         output = (OutputTotalEnergy, OutputKineticEnergy, OutputPotentialEnergy, OutputPosition, OutputVelocity, OutputQuantumSubsystem)
-        traj1 = run_dynamics(sim, tspan, u; dt, output, algorithm=Vern9(), abstol=1e-15, reltol=1e-15, saveat=dt)
+
+        dyn_test = @timed run_dynamics(sim, tspan, u; dt, output, algorithm=Vern9(), abstol=1e-15, reltol=1e-15, saveat=dt)
+        traj1 = dyn_test.value
         @test isapprox(var(traj1[:OutputTotalEnergy]), 0; atol=1e-6)
+        benchmark_results["FermiDirac Vern9"] = Dict("Time" => dyn_test.time, "Allocs" => dyn_test.bytes)
 
         u = DynamicsVariables(sim, v, r, FermiDiracState(0.0, 0.0))
-        traj2 = run_dynamics(sim, tspan, u; dt, output) # default algorithm is fixed timestep
+        
+        dyn_test = @timed run_dynamics(sim, tspan, u; dt, output) # default algorithm is fixed timestep
+        traj2 = dyn_test.value
         @test isapprox(var(traj2[:OutputTotalEnergy]), 0; atol=1e-6)
+        benchmark_results["FermiDirac fixed timestep"] = Dict("Time" => dyn_test.time, "Allocs" => dyn_test.bytes)
 
         @test traj1[:OutputKineticEnergy] ≈ traj2[:OutputKineticEnergy] rtol = 1e-3
         @test traj1[:OutputPotentialEnergy] ≈ traj2[:OutputPotentialEnergy] rtol = 1e-3
@@ -110,8 +124,12 @@ atoms = Atoms(:H)
         saveat = 0:0.1:20
         trajectories = 500
         output = TimeCorrelationFunctions.PopulationCorrelationFunction(sim, Diabatic())
-        ensemble = run_dynamics(sim, (0.0, 20.0), distribution;
+        
+        dyn_test = @timed begin
+            run_dynamics(sim, (0.0, 20.0), distribution;
             saveat, trajectories, output, reduction=MeanReduction(), dt=0.1)
+        end
+        ensemble = dyn_test.value
         result = [p[1, 1] - p[1, 2] for p in ensemble[:PopulationCorrelationFunction]]
 
         data = CSV.read(joinpath(@__DIR__, "reference_data", "gao_saller_jctc_2020_fig2b.csv"), DataFrame; header=false)
@@ -121,6 +139,7 @@ atoms = Atoms(:H)
             true_value = itp(t)
             @test isapprox(true_value, result[i]; atol=0.2)
         end
+        benchmark_results["SpinBoson population"] = Dict("Time" => dyn_test.time, "Allocs" => dyn_test.bytes)
     end
 end
 
@@ -130,6 +149,13 @@ end
     v = fill(100 / 2000, 1, 1, 10)
     r = fill(-10.0, 1, 1, 10)
     u = DynamicsVariables(sim, v, r, PureState(1, Adiabatic()))
-    solution = run_dynamics(sim, (0.0, 500.0), u, output=OutputTotalEnergy, dt=0.01)
+    dyn_test = @timed run_dynamics(sim, (0.0, 500.0), u, output=OutputTotalEnergy, dt=0.01)
+    solution =  dyn_test.value
     @test isapprox(var(solution[:OutputTotalEnergy]), 0; atol=1e-6)
+    benchmark_results["Ehrenfest RPMD"] = Dict("Time" => dyn_test.time, "Allocs" => dyn_test.bytes)
 end
+
+# Output benchmarking dict
+output_file = open("$(benchmark_dir)/ehrenfest.json", "w")
+JSON.print(output_file, benchmark_results)
+close(output_file)

--- a/test/Dynamics/ehrenfest_na.jl
+++ b/test/Dynamics/ehrenfest_na.jl
@@ -2,6 +2,10 @@ using Test
 using NQCDynamics
 using Statistics: var
 using OrdinaryDiffEq: Vern9
+import JSON
+
+benchmark_dir = get(ENV, "BENCHMARK_OUTPUT_DIR", "/tmp/nqcd_benchmark")
+benchmark_results = Dict{String, Any}("title_for_plotting" => "EhrenfestNA Tests")
 
 kT = 9.5e-4
 M = 30 # number of bath states
@@ -24,12 +28,18 @@ n_electrons = M ÷ 2
     tspan = (0.0, 2000.0)
     dt = 10.0
     output = (OutputTotalEnergy, OutputKineticEnergy, OutputPotentialEnergy, OutputPosition, OutputVelocity, OutputQuantumSubsystem)
-    traj1 = run_dynamics(sim, tspan, u; dt, output, algorithm=Vern9(), abstol=1e-15, reltol=1e-15, saveat=dt)
+    
+    dyn_test = @timed run_dynamics(sim, tspan, u; dt, output, algorithm=Vern9(), abstol=1e-15, reltol=1e-15, saveat=dt)
+    traj1 = dyn_test.value
     @test isapprox(var(traj1[:OutputTotalEnergy]), 0; atol=1e-6)
+    benchmark_results["Vern9"] = Dict("Time" => dyn_test.time, "Allocs" => dyn_test.bytes)
 
     u = DynamicsVariables(sim, v, r)
-    traj2 = run_dynamics(sim, tspan, u; dt, output) # default algorithm is fixed timestep
+    
+    dyn_test = @timed run_dynamics(sim, tspan, u; dt, output) # default algorithm is fixed timestep
+    traj2 = dyn_test.value
     @test isapprox(var(traj2[:OutputTotalEnergy]), 0; atol=1e-6)
+    benchmark_results["Fixed timestep"] = Dict("Time" => dyn_test.time, "Allocs" => dyn_test.bytes)
 
     # Confirm all quantities are the same for the different algorithms
     @test traj1[:OutputKineticEnergy] ≈ traj2[:OutputKineticEnergy] rtol=1e-3
@@ -38,6 +48,11 @@ n_electrons = M ÷ 2
     @test traj1[:OutputPosition] ≈ traj2[:OutputPosition] rtol=1e-3
     @test traj1[:OutputQuantumSubsystem] ≈ traj2[:OutputQuantumSubsystem] rtol=1e-2
 end
+
+# Output benchmarking dict
+output_file = open("$(benchmark_dir)/EhrenfestNA.json", "w")
+JSON.print(output_file, benchmark_results)
+close(output_file)
 
 # sim = Simulation{EhrenfestNA}(atoms, model)
 # v = zeros(1,1)

--- a/test/Dynamics/iesh.jl
+++ b/test/Dynamics/iesh.jl
@@ -8,6 +8,10 @@ using NQCDynamics.DynamicsMethods: SurfaceHoppingMethods
 using OrdinaryDiffEq
 using ComponentArrays
 using Unitful, UnitfulAtomic
+import JSON
+
+benchmark_dir = get(ENV, "BENCHMARK_OUTPUT_DIR", "/tmp/nqcd_benchmark")
+benchmark_results = Dict{String, Any}("title_for_plotting" => "IESH Tests")
 
 kT = 9.5e-4
 M = 30 # number of bath states
@@ -148,9 +152,17 @@ end
     tspan = (0.0, 100.0)
     dt = 1.0
     output = (OutputPosition, OutputVelocity, OutputQuantumSubsystem, OutputTotalEnergy)
-    traj1 = run_dynamics(sim, tspan, u; dt, algorithm=DynamicsMethods.IntegrationAlgorithms.VerletwithElectronics(), output)
-    traj2 = run_dynamics(sim, tspan, u; algorithm=Tsit5(), saveat=tspan[1]:dt:tspan[2], output, reltol=1e-6, abstol=1e-6)
-    traj3 = run_dynamics(sim, tspan, u; dt, algorithm=DynamicsMethods.IntegrationAlgorithms.VerletwithElectronics2(MagnusMidpoint(krylov=false), dt=dt / 5), output)
+    dyn_test = @timed run_dynamics(sim, tspan, u; dt, algorithm=DynamicsMethods.IntegrationAlgorithms.VerletwithElectronics(), output)
+    traj1 = dyn_test.value
+    benchmark_results["VerletwithElectronics"] = Dict("Time" => dyn_test.time, "Allocs" => dyn_test.bytes)
+    
+    dyn_test = @timed run_dynamics(sim, tspan, u; algorithm=Tsit5(), saveat=tspan[1]:dt:tspan[2], output, reltol=1e-6, abstol=1e-6)
+    traj2 = dyn_test.value
+    benchmark_results["Tsit5"] = Dict("Time" => dyn_test.time, "Allocs" => dyn_test.bytes)
+    
+    dyn_test = @timed run_dynamics(sim, tspan, u; dt, algorithm=DynamicsMethods.IntegrationAlgorithms.VerletwithElectronics2(MagnusMidpoint(krylov=false), dt=dt / 5), output)
+    traj3 = dyn_test.value
+    benchmark_results["VerletwithElectronics2"] = Dict("Time" => dyn_test.time, "Allocs" => dyn_test.bytes)
 
     # We cannot compare these when hopping is happening since the trajectories will be different. 
 end
@@ -160,7 +172,11 @@ end
     u = DynamicsVariables(sim, zeros(1, 1), 1000randn(1, 1))
     tspan = (0.0, 100000.0)
     dt = 100.0
-    traj = run_dynamics(sim, tspan, u; dt, output=(OutputQuantumSubsystem, OutputSurfaceHops))
+    
+    
+    dyn_test = @timed run_dynamics(sim, tspan, u; dt, output=(OutputQuantumSubsystem, OutputSurfaceHops))
+    traj = dyn_test.value
+    
     @test traj[:OutputSurfaceHops] > 0 # Ensure some hops occur
     norms = zeros(length(traj[:Time]))
     for i in eachindex(norms)
@@ -170,4 +186,10 @@ end
         end
     end
     @test all(i -> isapprox(i, n_electrons; rtol=1e-3), norms) # Test that decoherence conserves norm
+    benchmark_results["DecoherenceCorrectionEDC"] = Dict("Time" => dyn_test.time, "Allocs" => dyn_test.bytes)
 end
+
+# Output benchmarking dict
+output_file = open("$(benchmark_dir)/iesh.json", "w")
+JSON.print(output_file, benchmark_results)
+close(output_file)

--- a/test/Dynamics/langevin.jl
+++ b/test/Dynamics/langevin.jl
@@ -1,5 +1,9 @@
 using Test
 using NQCDynamics
+using JSON
+
+benchmark_dir = get(ENV, "BENCHMARK_OUTPUT_DIR", "/tmp/nqcd_benchmark")
+benchmark_results = Dict{String, Any}("title_for_plotting" => "Langevin")
 
 atoms = Atoms([:H])
 model = Harmonic()
@@ -8,4 +12,11 @@ sim = Simulation{Langevin}(atoms, model; temperature=1, γ=1)
 
 z = DynamicsVariables(sim, randn(1,1), randn(1,1))
 
-solution = run_dynamics(sim, (0.0, 500.0), z; output=OutputDynamicsVariables, dt=1)
+dyn_test = @timed run_dynamics(sim, (0.0, 500.0), z; output=OutputDynamicsVariables, dt=1)
+solution = dyn_test.value
+benchmark_results["Langevin"] = Dict("Time" => dyn_test.time, "Allocs" => dyn_test.bytes)
+
+# Output benchmarking dict
+output_file = open("$(benchmark_dir)/langevin.json", "w")
+JSON.print(output_file, benchmark_results)
+close(output_file)

--- a/test/Dynamics/rp_ehrenfest_na.jl
+++ b/test/Dynamics/rp_ehrenfest_na.jl
@@ -2,6 +2,10 @@ using Test
 using NQCDynamics
 using Statistics: var
 using OrdinaryDiffEq: Vern9
+import JSON
+
+benchmark_dir = get(ENV, "BENCHMARK_OUTPUT_DIR", "/tmp/nqcd_benchmark")
+benchmark_results = Dict{String, Any}("title_for_plotting" => "RPEhrenfestNA Tests")
 
 kT = 9.5e-4
 M = 30 # number of bath states
@@ -25,11 +29,16 @@ n_electrons = M ÷ 2
     tspan = (0.0, 2000.0)
     dt = 10.0
     output = (OutputTotalEnergy, OutputKineticEnergy, OutputPotentialEnergy, OutputPosition, OutputVelocity, OutputQuantumSubsystem)
-    traj1 = run_dynamics(sim, tspan, u; dt, output, algorithm=Vern9(), abstol=1e-10, reltol=1e-10, saveat=dt)
+    
+    dyn_test = @timed run_dynamics(sim, tspan, u; dt, output, algorithm=Vern9(), abstol=1e-10, reltol=1e-10, saveat=dt)
+    traj1 = dyn_test.value
     @test isapprox(var(traj1[:OutputTotalEnergy]), 0; atol=1e-6)
+    benchmark_results["Vern9"] = Dict("Time" => dyn_test.time, "Allocs" => dyn_test.bytes)
 
     u = DynamicsVariables(sim, v, r)
-    traj2 = run_dynamics(sim, tspan, u; dt, output) # default algorithm is fixed timestep
+    dyn_test = @timed run_dynamics(sim, tspan, u; dt, output) # default algorithm is fixed timestep
+    traj2 = dyn_test.value
+    benchmark_results["Fixed Timestep"] = Dict("Time" => dyn_test.time, "Allocs" => dyn_test.bytes)
     @test isapprox(var(traj2[:OutputTotalEnergy]), 0; atol=1e-6)
 
     # Confirm all quantities are the same for the different algorithms
@@ -39,6 +48,11 @@ n_electrons = M ÷ 2
     @test traj1[:OutputPosition] ≈ traj2[:OutputPosition] rtol=1e-3
     @test traj1[:OutputQuantumSubsystem] ≈ traj2[:OutputQuantumSubsystem] rtol=1e-2
 end
+
+# Output benchmarking dict
+output_file = open("$(benchmark_dir)/rp_ehrenfest_na.json", "w")
+JSON.print(output_file, benchmark_results)
+close(output_file)
 
 # sim = Simulation{EhrenfestNA}(atoms, model)
 # v = zeros(1,1)

--- a/test/Dynamics/rpbcme.jl
+++ b/test/Dynamics/rpbcme.jl
@@ -7,6 +7,10 @@ using Statistics: mean
 using StatsBase: sem
 using DataFrames, CSV
 using Interpolations
+import JSON
+
+benchmark_dir = get(ENV, "BENCHMARK_OUTPUT_DIR", "/tmp/nqcd_benchmark")
+benchmark_results = Dict{String, Any}("title_for_plotting" => "RPBCME Tests")
 
 ħω = 0.003
 Γ = 0.1
@@ -62,9 +66,13 @@ n_beads = 4
     v = VelocityBoltzmann(kT*n_beads, atoms.masses[1])
     distribution = DynamicalDistribution(v, r, (1,1,n_beads)) * PureState(1, Diabatic())
 
-    output = run_dynamics(sim, (0.0, 10000.0), distribution;
-        trajectories=100, output=(OutputPosition), saveat=100, dt=1.0
-    )
+    dyn_test = @timed begin
+        run_dynamics(sim, (0.0, 10000.0), distribution;
+            trajectories=100, output=(OutputPosition), saveat=100, dt=1.0
+        )
+    end
+    output = dyn_test.value
+    
     avg = zeros(101)
     for i in eachindex(output)
         for j in eachindex(avg)
@@ -84,12 +92,18 @@ n_beads = 4
         true_value = itp(t)
         @test isapprox(true_value, avg[i]; atol=5err[i], rtol=0.1)
     end
-    # Uncomment to see the comparison if the tests start failing
-    using Plots
-    p = plot()
-    plot!(data[!,1], data[!,2])
-    plot!(output[1][:Time], avg; yerr=err)
-    plot!(output[1][:Time], itp.(output[1][:Time]))
-    xlims!(0, 1e4)
-    display(p)
+    # # Uncomment to see the comparison if the tests start failing
+    # using Plots
+    # p = plot()
+    # plot!(data[!,1], data[!,2])
+    # plot!(output[1][:Time], avg; yerr=err)
+    # plot!(output[1][:Time], itp.(output[1][:Time]))
+    # xlims!(0, 1e4)
+    # display(p)
+    benchmark_results["RPBCME"] = Dict("Time" => dyn_test.time, "Allocs" => dyn_test.bytes)
 end
+
+# Output benchmarking dict
+output_file = open("$(benchmark_dir)/RPBCME.json", "w")
+JSON.print(output_file, benchmark_results)
+close(output_file)

--- a/test/Dynamics/rpcme.jl
+++ b/test/Dynamics/rpcme.jl
@@ -6,6 +6,10 @@ using Statistics: mean
 using StatsBase: sem
 using DataFrames, CSV
 using Interpolations
+import JSON
+
+benchmark_dir = get(ENV, "BENCHMARK_OUTPUT_DIR", "/tmp/nqcd_benchmark")
+benchmark_results = Dict{String, Any}("title_for_plotting" => "RPCME Tests")
 
 ħω = 0.003
 Γ = 0.003
@@ -59,10 +63,14 @@ n_beads = 4
     v = VelocityBoltzmann(kTinitial * n_beads, atoms.masses[1])
     distribution = DynamicalDistribution(v, r, (1, 1, n_beads)) * PureState(1, Diabatic())
 
-    output = run_dynamics(sim, (0.0, 200 / Γ), distribution; trajectories=250,
-        output=(OutputKineticEnergy, OutputTotalEnergy, OutputPotentialEnergy, OutputDiscreteState, OutputSpringEnergy, OutputCentroidKineticEnergy),
-        abstol=1e-12, reltol=1e-12, saveat=2 / Γ, dt=1 / ħω / 10
-    )
+    dyn_test = @timed begin
+        run_dynamics(sim, (0.0, 200 / Γ), distribution; trajectories=250,
+            output=(OutputKineticEnergy, OutputTotalEnergy, OutputPotentialEnergy, OutputDiscreteState, OutputSpringEnergy, OutputCentroidKineticEnergy),
+            abstol=1e-12, reltol=1e-12, saveat=2 / Γ, dt=1 / ħω / 10
+        )
+    end
+    output = dyn_test.value
+    
     avg = mean(o[:OutputCentroidKineticEnergy] for o in output) ./ kT
     err = zero(avg)
     for i in eachindex(err)
@@ -83,5 +91,10 @@ n_beads = 4
     # plot!(output[1][:Time] .* Γ, avg, yerr=err)
     # plot!(output[1][:Time] .* Γ, itp.(output[1][:Time] .* Γ))
     # display(p)
+    benchmark_results["Phonon relaxation"] = Dict("Time" => dyn_test.time, "Allocs" => dyn_test.bytes)
 end
 
+# Output benchmarking dict
+output_file = open("$(benchmark_dir)/rpcme.json", "w")
+JSON.print(output_file, benchmark_results)
+close(output_file)

--- a/test/Dynamics/rpecmm.jl
+++ b/test/Dynamics/rpecmm.jl
@@ -4,6 +4,10 @@ using NQCDynamics
 using FiniteDiff
 using LinearAlgebra: norm
 using OrdinaryDiffEq: Tsit5
+import JSON
+
+benchmark_dir = get(ENV, "BENCHMARK_OUTPUT_DIR", "/tmp/nqcd_benchmark")
+benchmark_results = Dict{String, Any}("title_for_plotting" => "RPeCMM Tests")
 
 function test_motion!(sim::RingPolymerSimulation{<:eCMM}, u)
     f(x) = DynamicsUtils.classical_hamiltonian(sim, x)
@@ -31,15 +35,19 @@ u1 = DynamicsVariables(sim1, v, r, PureState(1))
 test_motion!(sim, u)
 test_motion!(sim1, u1)
 
-sol = run_dynamics(sim, (0, 100.0), u; output=(OutputTotalEnergy, OutputMappingPosition, OutputMappingMomentum), dt=0.01)
+dyn_test = @timed run_dynamics(sim, (0, 100.0), u; output=(OutputTotalEnergy, OutputMappingPosition, OutputMappingMomentum), dt=0.01)
+sol = dyn_test.value
 @test sol[:OutputTotalEnergy][1] ≈ sol[:OutputTotalEnergy][end] rtol=1e-3
+benchmark_results["RPeCMM γ=0.0"] = Dict("Time" => dyn_test.time, "Allocs" => dyn_test.bytes)
 qmap = sol[:OutputMappingPosition]
 pmap = sol[:OutputMappingMomentum]
 total_population = sum.(DynamicsMethods.MappingVariableMethods.mapping_kernel.(qmap, pmap, sim.method.γ))
 @test all(isapprox.(total_population, 1, rtol=1e-2))
 
-sol = run_dynamics(sim1, (0, 100.0), u1; output=(OutputTotalEnergy, OutputMappingPosition, OutputMappingMomentum), dt=0.01)
+dyn_test = @timed run_dynamics(sim1, (0, 100.0), u1; output=(OutputTotalEnergy, OutputMappingPosition, OutputMappingMomentum), dt=0.01)
+sol = dyn_test.value
 @test sol[:OutputTotalEnergy][1] ≈ sol[:OutputTotalEnergy][end] rtol=1e-3
+benchmark_results["RPeCMM γ=0.5"] = Dict("Time" => dyn_test.time, "Allocs" => dyn_test.bytes)
 qmap = sol[:OutputMappingPosition]
 pmap = sol[:OutputMappingMomentum]
 total_population = sum.(DynamicsMethods.MappingVariableMethods.mapping_kernel.(qmap, pmap, sim1.method.γ))
@@ -73,3 +81,8 @@ end
     sol1 = run_dynamics(sim1, (0, 10.0), u; output=OutputDynamicsVariables, algorithm=Tsit5(), reltol=1e-10, abstol=1e-10, saveat=sol[:Time])
     @test sol[:OutputDynamicsVariables] ≈ sol1[:OutputDynamicsVariables] rtol=1e-2
 end
+
+# Output benchmarking dict
+output_file = open("$(benchmark_dir)/RPeCMM.json", "w")
+JSON.print(output_file, benchmark_results)
+close(output_file)

--- a/test/Dynamics/spin_mapping.jl
+++ b/test/Dynamics/spin_mapping.jl
@@ -6,6 +6,11 @@ using NQCDynamics: DynamicsMethods, DynamicsUtils
 using NQCDynamics.DynamicsMethods.MappingVariableMethods
 using OrdinaryDiffEq
 using DiffEqDevTools
+import JSON
+
+benchmark_dir = get(ENV, "BENCHMARK_OUTPUT_DIR", "/tmp/nqcd_benchmark")
+benchmark_results = Dict{String, Any}("title_for_plotting" => "SpinMapping Tests")
+
 Random.seed!(1)
 
 atoms = Atoms(1)
@@ -39,9 +44,16 @@ end
 end
 
 @testset "Algorithm comparison" begin
-    sol = run_dynamics(sim, (0, 3.0), u; output=OutputDynamicsVariables, dt=1e-2, algorithm=DynamicsMethods.IntegrationAlgorithms.MInt())
-    sol1 = run_dynamics(sim, (0, 3.0), u; output=OutputDynamicsVariables, algorithm=Tsit5(), reltol=1e-10, abstol=1e-10, saveat=sol[:Time])
+    dyn_test = @timed run_dynamics(sim, (0, 3.0), u; output=OutputDynamicsVariables, dt=1e-2, algorithm=DynamicsMethods.IntegrationAlgorithms.MInt())
+    sol = dyn_test.value
+    
+    dyn_test1 = @timed run_dynamics(sim, (0, 3.0), u; output=OutputDynamicsVariables, algorithm=Tsit5(), reltol=1e-10, abstol=1e-10, saveat=sol[:Time])
+    sol1 = dyn_test1.value
+    
     @test sol[:OutputDynamicsVariables] ≈ sol1[:OutputDynamicsVariables] rtol=1e-2
+    
+    benchmark_results["MInt"] = Dict("Time" => dyn_test.time, "Allocs" => dyn_test.bytes)
+    benchmark_results["Tsit5"] = Dict("Time" => dyn_test.time, "Allocs" => dyn_test.bytes)
 end
 
 @testset "MInt algorithm convergence" begin
@@ -55,3 +67,8 @@ end
     res = analyticless_test_convergence(dts, prob, alg, setup)
     @test res.𝒪est[:final] ≈ 2 atol=0.1
 end
+
+# Output benchmarking dict
+output_file = open("$(benchmark_dir)/SpinMapping.json", "w")
+JSON.print(output_file, benchmark_results)
+close(output_file)

--- a/test/benchmark_plots.jl
+++ b/test/benchmark_plots.jl
@@ -1,0 +1,11 @@
+import JSON
+using CairoMakie
+using Glob
+
+# Get information from outside the plotting script: What is the newest version and what are we comparing to?
+newest_version = get(ENV, "CURRENT_VERSION", "v0.15.1") # A known tested version
+github_context = get(ENV, "NEW_VERSION", "new") # The new thing to test. 
+
+# Base path of the benchmark repository
+benchmark_path = 
+

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,6 +1,7 @@
 using Test
 using SafeTestsets
 using NQCDynamics
+using JSON
 
 const GROUP = get(ENV, "GROUP", "All")
 


### PR DESCRIPTION
This applies the changes in #390 to the current release, v0.15.1, to generate base timings to compare future PRs to. I need this PR to run on the same hardware as subsequent tests, which is why this PR is needed. 