### PR TITLE
📍 OrdinaryDiffEq < 6.102.0 as a temporary fix

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "NQCDynamics"
 uuid = "36248dfb-79eb-4f4d-ab9c-e29ea5f33e14"
 authors = ["James <james.gardner1421@gmail.com>"]
-version = "1.0.1"
+version = "1.0.2"
 
 [deps]
 AdvancedHMC = "0bf59076-c3b1-5ca4-86bd-e02cd72cde3d"
@@ -71,7 +71,7 @@ NQCCalculators = "1"
 NQCDistributions = "0.1, 1"
 NQCModels = "0.10, 1"
 Optim = "1"
-OrdinaryDiffEq = "5, 6"
+OrdinaryDiffEq = "< 6.102.0"
 Parameters = "0.12"
 PeriodicTable = "1"
 ProgressMeter = "1"

--- a/src/Project.toml
+++ b/src/Project.toml
@@ -1,2 +1,0 @@
-[deps]
-NQCModels = "c814dc9f-a51f-4eaf-877f-82eda4edad48"


### PR DESCRIPTION
Fixes #427 temporarily, but we still need to solve various open issues anyway which will overwrite this change. 