### PR TITLE
🐞 Fix diatomic transform

### DIFF
--- a/test/Analysis/diatomic.jl
+++ b/test/Analysis/diatomic.jl
@@ -37,7 +37,7 @@ end
     @test isapprox(eft |> diag |> sum, eft_internal |> diag |> sum)
     # Ensure doing the back-transform on the forward transform gives back the same matrix. 
     eft_cartesian_again = NQCDynamics.Analysis.Diatomic.transform_from_internal_coordinates(
-        eft_intnernal,
+        eft_internal,
         first_structure.positions,
         diatomic_indices...,
         simulation

--- a/test/Analysis/diatomic.jl
+++ b/test/Analysis/diatomic.jl
@@ -28,7 +28,7 @@ end
     diatomic_indices = [55,56]
     simulation=Simulation(first_structure.atoms, Free(), cell=first_structure.cell)
     # Ensure internal coordinate transformation is trace-conserving
-    eft_intnernal = NQCDynamics.Analysis.Diatomic.transform_to_internal_coordinates(
+    eft_internal = NQCDynamics.Analysis.Diatomic.transform_to_internal_coordinates(
         eft,
         first_structure.positions,
         diatomic_indices...,
@@ -42,5 +42,8 @@ end
         diatomic_indices...,
         simulation
     )
-    @test isapprox.(eft, eft_cartesian_again)
+    matrix_comparison = isapprox.(eft, eft_cartesian_again)
+    for idx in eachindex(matrix_comparison)
+        @test matrix_comparison[idx]
+    end
 end

--- a/test/Analysis/diatomic.jl
+++ b/test/Analysis/diatomic.jl
@@ -22,7 +22,7 @@ end
 @testset "Internal coordinate transformation" begin
     structure_import = NQCDynamics.read_extxyz("artifacts/desorption_test.xyz")
     # Take only the first structure
-    first_structure = NQCDynamics.NQCBase.Structure(structure_import[1], structure_import[2][1], structure_import[3])
+    first_structure = first(structure.import)
     # Generate a random (symmetric) friction tensor
     eft = Symmetric(rand(6,6)) |> Matrix
     diatomic_indices = [55,56]

--- a/test/Analysis/diatomic.jl
+++ b/test/Analysis/diatomic.jl
@@ -4,6 +4,7 @@ using Unitful, UnitfulAtomic
 using PythonCall
 using NQCModels
 using NQCDInterfASE
+using LinearAlgebra
 using JLD2
 
 @testset "Desorption Analysis" begin
@@ -16,4 +17,30 @@ using JLD2
     diatomic_indices=[55,56]
     @test Analysis.Diatomic.get_desorption_frame(desorption_dynamicsvariables, diatomic_indices, simulation; surface_distance_threshold=austrip(2.4u"Å")) == 2675
     @test Analysis.Diatomic.get_desorption_angle(desorption_dynamicsvariables, diatomic_indices, simulation; surface_distance_threshold=austrip(2.4u"Å")) ≈ 28.05088202518
+end
+
+@testset "Internal coordinate transformation" begin
+    structure_import = NQCDynamics.read_extxyz("artifacts/desorption_test.xyz")
+    # Take only the first structure
+    first_structure = NQCDynamics.NQCBase.Structure(structure_import[1], structure_import[2][1], structure_import[3])
+    # Generate a random (symmetric) friction tensor
+    eft = Symmetric(rand(6,6)) |> Matrix
+    diatomic_indices = [55,56]
+    simulation=Simulation(first_structure.atoms, Free(), cell=first_structure.cell)
+    # Ensure internal coordinate transformation is trace-conserving
+    eft_intnernal = NQCDynamics.Analysis.Diatomic.transform_to_internal_coordinates(
+        eft,
+        first_structure.positions,
+        diatomic_indices...,
+        simulation
+    )
+    @test isapprox(eft |> diag |> sum, eft_internal |> diag |> sum)
+    # Ensure doing the back-transform on the forward transform gives back the same matrix. 
+    eft_cartesian_again = NQCDynamics.Analysis.Diatomic.transform_from_internal_coordinates(
+        eft_intnernal,
+        first_structure.positions,
+        diatomic_indices...,
+        simulation
+    )
+    @test isapprox.(eft, eft_cartesian_again)
 end


### PR DESCRIPTION
- [x] Fix flipped indices and other mistakes in internal coordinate transform matrix that was causing `transform_to_internal_coordinates` to give nonsensical numbers. 
- [x] Add a unit test which ensures forward transform ⋅ back transform retain the original matrix. 
- [x] Add unit test to ensure transform matrix is unitary
