### PR TITLE
Surface site classification (2nd attempt)

### DIFF
--- a/docs/src/api/NQCDynamics/analysis.md
+++ b/docs/src/api/NQCDynamics/analysis.md
@@ -5,7 +5,7 @@ start_time = time()
 # Analysis
 
 ```@autodocs
-Modules=[NQCDynamics.Analysis, NQCDynamics.Analysis.Diatomic, NQCDynamics.Analysis.RigidRotator, NQCDynamics.Analysis.Postprocess]
+Modules=[NQCDynamics.Analysis, NQCDynamics.Analysis.Diatomic, NQCDynamics.Analysis.RigidRotator, NQCDynamics.Analysis.Postprocess, NQCDynamics.Analysis.HighSymmetrySites]
 ```
 
 ```@setup logging

--- a/docs/src/examples/surface_site_classification.md
+++ b/docs/src/examples/surface_site_classification.md
@@ -1,0 +1,196 @@
+```@setup logging
+@info "Expanding src/examples/surface_site_classification.md..."
+start_time = time()
+```
+# Surface site classification for adsorbates
+
+This example demonstrates how to use the `HighSymmetrySites` analysis module to classify the positions of adsorbate molecules on a metal surface according to high-symmetry surface sites.
+
+The `HighSymmetrySites` module is useful for analyzing molecular dynamics trajectories on periodic surfaces, particularly for studying adsorption, desorption, and surface diffusion processes.
+
+## Setting up the system
+
+We'll create a simple example with a hydrogen molecule on an FCC(100) metal surface.
+First, let's set up the basic simulation cell and atoms.
+
+```@example surface_sites
+using NQCDynamics
+using LinearAlgebra
+
+# Create a periodic cell for the surface (10×10 Å in XY, 20 Å in Z)
+cell = PeriodicCell(diagm([10.0, 10.0, 20.0]))
+
+# Create atoms: 4 surface atoms and 2 hydrogen atoms (adsorbate)
+atoms = Atoms([:Au, :Au, :Au, :Au, :H, :H])
+nothing # hide
+```
+
+## Defining the slab structure
+
+To use the site classification functionality, we need to define a `SlabStructure` that contains:
+- The indices of adsorbate atoms to track
+- The symmetry site definitions for the surface
+- The supercell size relative to the primitive unit cell
+
+For an FCC(100) surface, predefined site definitions are available via `FCC100Sites`.
+
+```@example surface_sites
+using NQCDynamics.Analysis.HighSymmetrySites
+
+# Define which atoms are adsorbates (indices 5 and 6 for the H atoms)
+adsorbate_indices = [5, 6]
+
+# The simulation cell is a 2×2 supercell of the primitive FCC(100) unit cell
+supercell_size = [2.0, 2.0, 1.0]
+
+# Create the slab structure
+slab = SlabStructure(
+    adsorbate_indices,
+    FCC100Sites,  # Predefined sites: :top, :bridge, :fcc
+    supercell_size
+)
+nothing # hide
+```
+
+## Classifying a single position
+
+Let's classify a single position to see which surface site it corresponds to.
+The `positions_to_category` function determines the closest high-symmetry site.
+
+```@example surface_sites
+# Position at the origin (a top site in FCC100)
+position_top = [0.0, 0.0, 5.0]  # Only X,Y coordinates are used
+site_top = positions_to_category(
+    position_top,
+    FCC100Sites,
+    PeriodicCell(diagm([5.0, 5.0]))  # Primitive cell (half of our supercell)
+)
+println("Position [0.0, 0.0] is classified as: ", site_top)
+
+# Position at the bridge site
+position_bridge = [2.5, 0.0, 5.0]  # At the bridge between two top sites
+site_bridge = positions_to_category(
+    position_bridge,
+    FCC100Sites,
+    PeriodicCell(diagm([5.0, 5.0])),
+    snap_to_site=0.5  # Distance tolerance in Angstroms
+)
+println("Position [2.5, 0.0] is classified as: ", site_bridge)
+
+# Position at the hollow site
+position_hollow = [2.5, 2.5, 5.0]  # At the hollow (fcc) site
+site_hollow = positions_to_category(
+    position_hollow,
+    FCC100Sites,
+    PeriodicCell(diagm([5.0, 5.0])),
+    snap_to_site=0.5
+)
+println("Position [2.5, 2.5] is classified as: ", site_hollow)
+```
+
+## Analyzing a trajectory
+
+To analyze an entire trajectory, we can use `classify_every_frame`.
+This function processes all frames and returns the site classification for each adsorbate at each timestep.
+
+```@example surface_sites
+# Create a simple model for demonstration
+model = Free(3)  # Free particle model
+sim = Simulation(atoms, model; cell=cell)
+
+# Create some example trajectory data with different positions
+positions = [
+    [0.0 0.0 0.0 0.0 0.1 0.1;    # Frame 1: H atoms near top site
+     0.0 0.0 0.0 0.0 0.1 0.1;
+     10.0 10.0 10.0 10.0 10.0 10.0],
+    [0.0 0.0 0.0 0.0 2.5 2.5;    # Frame 2: H atoms near bridge site
+     0.0 0.0 0.0 0.0 0.1 0.1;
+     10.0 10.0 10.0 10.0 10.0 10.0],
+    [0.0 0.0 0.0 0.0 2.4 2.4;    # Frame 3: H atoms near hollow site
+     0.0 0.0 0.0 0.0 2.6 2.6;
+     10.0 10.0 10.0 10.0 10.0 10.0],
+]
+
+# Create DynamicsVariables for each frame
+trajectory = [DynamicsVariables(sim, rand(3,6), pos) for pos in positions]
+
+# Classify all frames
+site_classifications = classify_every_frame(
+    trajectory,
+    cell,
+    slab,
+    snap_to_site=0.5  # Tolerance for site assignment
+)
+
+# Display results
+println("\nTrajectory analysis:")
+for (atom_idx, atom_sites) in enumerate(site_classifications)
+    println("Adsorbate atom $(adsorbate_indices[atom_idx]):")
+    for (frame, site) in enumerate(atom_sites)
+        println("  Frame $frame: $site")
+    end
+end
+```
+
+## Available surface facets
+
+The `HighSymmetrySites` module includes predefined site definitions for several common FCC metal surface facets:
+
+### FCC(100) - `FCC100Sites`
+- `:top` - Atop sites (directly above a surface atom)
+- `:bridge` - Bridge sites (between two surface atoms)
+- `:fcc` - Four-fold hollow site
+
+### FCC(110) - `FCC110Sites`
+- `:top` - Atop sites
+- `:long_bridge` - Long bridge sites
+- `:short_bridge` - Short bridge sites
+- `:center_hollow` - Center hollow sites
+- `:step_hollow` - Step hollow sites
+
+### FCC(111) - `FCC111Sites`
+- `:top` - Atop sites
+- `:bridge` - Bridge sites
+- `:hollow` - Three-fold hollow sites
+
+### FCC(211) - `FCC211Sites`
+- `:step_edge` - Step edge sites
+- `:short_step` - Short step sites
+- `:fcc_high` - High FCC hollow sites
+- `:fcc_low` - Low FCC hollow sites
+- `:long_step` - Long step sites
+
+## Custom site definitions
+
+You can also define custom site positions for other surface structures:
+
+```@example surface_sites
+# Define custom sites (in fractional coordinates)
+custom_sites = Dict(
+    :custom_site_A => [[0.25, 0.25], [0.75, 0.75]],
+    :custom_site_B => [[0.25, 0.75], [0.75, 0.25]],
+)
+
+# Use with your own SlabStructure
+custom_slab = SlabStructure(
+    [5, 6],  # Adsorbate indices
+    custom_sites,
+    [2.0, 2.0, 1.0]
+)
+nothing # hide
+```
+
+## Tips for usage
+
+1. **Distance tolerance**: The `snap_to_site` parameter controls how close a position must be to a defined site to be classified. Positions further away are classified as `:other`.
+
+2. **Fractional coordinates**: Set `fractional=true` if your positions are already in fractional coordinates relative to the unit cell.
+
+3. **Periodic boundaries**: The module automatically handles periodic boundary conditions, so adsorbates near cell edges are correctly classified.
+
+4. **2D only**: This module only considers X and Y coordinates. The surface must lie in the XY plane.
+
+```@setup logging
+runtime = round(time() - start_time; digits=2)
+@info "...done after $runtime s."
+```

--- a/docs/src/output_and_analysis/intro.md
+++ b/docs/src/output_and_analysis/intro.md
@@ -47,3 +47,56 @@ These functions take into account periodic copies of the atoms in question, retu
 
 ### Analysis of diatomic molecules
 [`NQCDynamics.Analysis.Diatomic`](@ref Analysis)
+
+### Surface site classification
+[`NQCDynamics.Analysis.HighSymmetrySites`](@ref Analysis.HighSymmetrySites) provides functionality for classifying adsorbate positions on periodic surface slabs according to high-symmetry surface sites.
+
+This module is particularly useful for analyzing trajectories of molecules on metal surfaces, where you want to track whether adsorbates are located at top, bridge, hollow, or other characteristic sites.
+
+**Important:** This code only works for 2D positions in X and Y, so the surface must lie in the XY plane.
+
+#### Predefined surface facets
+
+The module includes predefined site definitions for common FCC metal surface facets:
+- `FCC100Sites` - (100) surface with top, bridge, and hollow sites
+- `FCC110Sites` - (110) surface with top, long bridge, short bridge, center hollow, and step hollow sites
+- `FCC111Sites` - (111) surface with top, bridge, and hollow sites
+- `FCC211Sites` - (211) stepped surface with step edge, short step, fcc high, fcc low, and long step sites
+
+#### Basic usage
+
+To classify adsorbate positions, you need to:
+1. Define a `SlabStructure` containing:
+   - `adsorbate_indices`: indices of atoms to track
+   - `symmetry_sites`: dictionary mapping site names to their fractional coordinates
+   - `supercell_size`: size of the simulation cell relative to the primitive cell
+2. Use `positions_to_category` to classify a single position, or
+3. Use `classify_every_frame` to analyze an entire trajectory
+
+#### Example
+
+```julia
+using NQCDynamics
+
+# Define the slab structure for an FCC(100) surface
+cell = PeriodicCell(diagm([10.0, 10.0, 20.0]))  # 10×10 Å surface cell
+slab = Analysis.HighSymmetrySites.SlabStructure(
+    [1, 2],  # Track atoms 1 and 2
+    Analysis.HighSymmetrySites.FCC100Sites,  # Use FCC(100) site definitions
+    [2.0, 2.0, 1.0]  # 2×2 supercell in XY
+)
+
+# Classify positions from a trajectory
+# trajectory should be a vector of DynamicsVariables
+sites = Analysis.HighSymmetrySites.classify_every_frame(
+    trajectory,
+    cell,
+    slab,
+    snap_to_site=0.3  # Distance tolerance in Angstroms
+)
+
+# sites[i] contains the classified site for adsorbate i at each frame
+# Each site is a Symbol like :top, :bridge, :fcc, or :other
+```
+
+For more details, see the [API documentation](@ref Analysis.HighSymmetrySites).

--- a/src/Analysis/Analysis.jl
+++ b/src/Analysis/Analysis.jl
@@ -8,6 +8,10 @@ using Reexport: @reexport
 include("diatomic.jl")
 export Diatomic
 
+# Surface facet symmetry site classification
+include("high-symmetry_sites.jl")
+export HighSymmetrySites
+
 # Allow re-processing of simulation data.
 include("postprocess.jl")
 export Postprocess

--- a/src/Analysis/high-symmetry_sites.jl
+++ b/src/Analysis/high-symmetry_sites.jl
@@ -159,7 +159,7 @@ Classifies the adsorption site of adsorbate atoms for every frame in a trajector
 function classify_every_frame(
 	trajectory, 
     cell::PeriodicCell,
-    slab::SlabStructure,
+    slab::SlabStructure;
 	fractional::Bool = false,
 	snap_to_site::Float64 = 0.03,
 )

--- a/src/Analysis/high-symmetry_sites.jl
+++ b/src/Analysis/high-symmetry_sites.jl
@@ -1,0 +1,197 @@
+"""
+These analysis functions contain some postprocessing code to associate positions of adsorbate molecules on a surface slab with high-symmetry locations on the surface slab. 
+
+Base definitions for fcc metal surface facets are included, but there are options to expand this further. 
+
+**This code only works for 2D positions in X and Y, so the surface needs to lie in the XY plane.**
+
+"""
+module HighSymmetrySites
+
+
+using NQCDynamics: AbstractSimulation, PeriodicCell, get_positions
+
+export SlabStructure, FCC100Sites, FCC110Sites, FCC111Sites, FCC211Sites, positions_to_category, classify_every_frame
+
+struct SlabStructure
+    adsorbate_indices::Vector{Int}
+    symmetry_sites::Dict{Symbol, Vector{Vector{Float64}}}
+    supercell_size::Vector{Float64}
+end
+
+const FCC100Sites = Dict(
+    :top => vec([vcat(i...) for i in Iterators.product([0.0,1.0], [0.0,1.0])]),
+    :bridge => [
+      [0.5, 0.0],
+      [0.5, 1.0],
+      [0.0, 0.5],
+      [1.0, 0.5],
+    ],
+    :fcc => [
+      [0.5, 0.5],
+    ],
+)
+const FCC110Sites = Dict(
+    :top => vec([vcat(i...) for i in Iterators.product([0.0,1.0], [0.0,1.0])]),
+    :long_bridge => [
+      [0.5, 0.0],
+      [0.5, 1.0],
+    ],
+    :short_bridge => [
+      [0.0, 0.5],
+      [1.0, 0.5],
+    ],
+    :center_hollow => [
+      [0.5, 0.5],
+    ],
+    :step_hollow => [
+      [0.25, 0.5],
+      [0.75, 0.5],
+    ],
+)
+const FCC111Sites = Dict(
+    :top => vec([vcat(i...) for i in Iterators.product([0.0,1.0], [0.0,1.0])]),
+    :fcc => [[0.33,0.33]],
+    :hcp => [[0.66,0.66]],
+    :bridge => [
+      [0.5,0.0],
+      [0.5,0.5],
+      [0.0,0.5],
+      [1.0,0.5],
+      [0.5,1.0],
+    ],
+)
+const FCC211Sites = Dict( # Based on Cao2018 site definitions
+:step_edge => vec([vcat(i...) for i in Iterators.product([0.0,1.0], [0.0,1.0])]), # Top sites, marking desorption bridged over the step edge
+:short_step => [ # This is the higher hollow site close to the step edge and would count for desorption via the step edge. Site 1 in Cao2018
+  [0.125, 0.5, ] #
+], 
+:fcc_high => [ # Site 2 in Cao2018, equivalent to desorption not over the step edge
+  [0.5, 0, ],
+  [0.5, 1.0, ],
+],
+:fcc_low => [ # This is hollow site 3 in Cao2018, equivalent to desorption not over the step edge
+  [0.75,0.0, ],
+  [0.75,1.0, ],
+],
+:long_step => [ # This is hollow site 4, the lower one with the higher step edge, counting for desorption over the higher step.
+  [0.875, 0.5, ],
+], #Not really sure where b2 goes. 
+)
+
+"""
+    positions_to_category(position, categories, cell::PeriodicCell; fractional::Bool = false, snap_to_site::Float64 = 0.03)
+
+Classifies a given 2D position according to its proximity to high-symmetry surface sites.
+
+# Arguments
+- `position`: A 2-element (or longer, only first 2D used) vector representing the coordinates to classify.
+- `categories`: A dictionary mapping site names (as Symbols) to lists of site coordinates.
+- `cell::PeriodicCell`: The surface unit cell used to calculate distances and perform coordinate transformations.
+- `fractional::Bool = false`: Whether to use fractional coordinates to determine distances to sites. If `true`, `position` is mapped directly to the sites; if `false`, converts to fractional using `cell`.
+- `snap_to_site::Float64 = 0.03`: The distance tolerance (in the same units as position/cell) for snapping to a given site category.
+
+# Returns
+- The key of the closest site category (from `categories`) if within `snap_to_site` of any defined site. If not within this range or outside the cell, returns `:other`.
+
+# Notes
+- Positions are always truncated to 2D before classification.
+- If the position is not inside the periodic cell, returns `:other`.
+- Site assignment is based on the minimum Euclidean distance to any site in each category.
+"""
+function positions_to_category(
+	position, 
+	categories, 
+	cell::PeriodicCell; 
+	fractional::Bool=false, 
+	snap_to_site::Float64=0.03,
+)
+	position = first(position,2) # Ensure we only ever carry X and Y
+	category_names = collect(keys(categories))
+	if !check_atoms_in_cell(cell, hcat(position))
+		return :other
+	else
+		position_copy = position
+		# Fractionalise positions if requested.
+		fractional ? position_copy = cell.inverse * position_copy : nothing
+		site_distances = Float64[]
+		for site in category_names
+			if fractional
+				push!(site_distances, minimum([norm(position_copy - point) for point in categories[site]])) # Gets closest distance for each category
+			else
+				push!(site_distances, minimum([norm(position_copy - cell.vectors * point) for point in categories[site]])) # Gets closest distance for each category
+			end
+		end
+	end
+	if any(site_distances .≤ snap_to_site) # Check if any category is sufficiently close
+		return category_names[argmin(site_distances)] # Return the classified category
+	else
+		return :other
+	end
+end
+
+"""
+    classify_every_frame(
+        trajectory,
+        cell::PeriodicCell,
+        slab::SlabStructure,
+        fractional::Bool = false,
+        snap_to_site::Float64 = 0.03,
+    )
+
+Classifies the adsorption site of adsorbate atoms for every frame in a trajectory.
+
+# Arguments
+- `trajectory`: Vector{DynamicsVariables type} of structures to classify. 
+- `cell::PeriodicCell`: The periodic cell representation of the simulation.
+- `slab::SlabStructure`: Slab structure object containing adsorbate atom indices, supercell size, and symmetry site information.
+- `fractional::Bool = false`: If `true`, uses fractional coordinates for site matching; otherwise, uses Cartesian coordinates.
+- `snap_to_site::Float64 = 0.03`: Distance tolerance for assigning a position to a high-symmetry site.
+
+# Returns
+- A vector of vectors, where each inner vector contains the classified site (as a `Symbol`) for an adsorbate atom at one frame.
+
+# Notes
+- Each adsorbate atom is assigned to a symmetry site or `:other` for each trajectory frame.
+- Positions are wrapped back into the primitive cell before site classification.
+- Uses `positions_to_category` to perform the categorization for each atom in each frame.
+"""
+function classify_every_frame(
+	trajectory, 
+    cell::PeriodicCell,
+    slab::SlabStructure,
+	fractional::Bool = false,
+	snap_to_site::Float64 = 0.03,
+)
+	# Determine a 2D representation of the unit cell first
+    fullsize_cell = cell.vectors
+	primitive_cell = PeriodicCell(fullsize_cell ./ slab.supercell_size)
+	primitive_cell_2d = PeriodicCell(getindex(fullsize_cell ./ slab.supercell_size, 1:2, 1:2))
+
+	site_associations = [Symbol[] for _ in eachindex(slab.adsorbate_indices)] # Generate site association vector containing info for each adsorbate atom. 
+	@inbounds for trajectory_frame in eachindex(trajectory)
+        @inbounds for (output_list_index, atom_index) in enumerate(slab.adsorbate_indices)
+            position_H = hcat(
+                get_positions(
+                    trajectory[trajectory_frame]
+                )[:, atom_index]
+            )
+            # Move into primitive unit cell
+            apply_cell_boundaries!(primitive_cell, position_H)
+            position_H = vec(position_H)
+            # Then categorise
+            category = positions_to_category(
+                position_H,
+                slab.symmetry_sites,
+                primitive_cell_2d,
+                fractional=fractional,
+                snap_to_site=snap_to_site
+            )
+            push!(site_associations[output_list_index], category)
+        end
+	end
+	return site_associations
+end
+
+
+end

--- a/src/Analysis/high-symmetry_sites.jl
+++ b/src/Analysis/high-symmetry_sites.jl
@@ -123,6 +123,7 @@ function positions_to_category(
 			end
 		end
 	end
+  @debug "Site distances:" sites = category_names distances = site_distances
 	if any(site_distances .≤ snap_to_site) # Check if any category is sufficiently close
 		return category_names[argmin(site_distances)] # Return the classified category
 	else

--- a/src/Analysis/high-symmetry_sites.jl
+++ b/src/Analysis/high-symmetry_sites.jl
@@ -51,14 +51,15 @@ const FCC110Sites = Dict(
 )
 const FCC111Sites = Dict(
     :top => vec([vcat(i...) for i in Iterators.product([0.0,1.0], [0.0,1.0])]),
-    :fcc => [[0.33,0.33]],
-    :hcp => [[0.66,0.66]],
+    :hollow => [
+      [0.33,0.33],
+      [0.66,0.66],
+    ],
     :bridge => [
-      [0.5,0.0],
-      [0.5,0.5],
-      [0.0,0.5],
-      [1.0,0.5],
-      [0.5,1.0],
+      [0.5, 0.0],
+      [0.5, 1.0],
+      [0.0, 0.5],
+      [1.0, 0.5],
     ],
 )
 const FCC211Sites = Dict( # Based on Cao2018 site definitions

--- a/src/Analysis/high-symmetry_sites.jl
+++ b/src/Analysis/high-symmetry_sites.jl
@@ -10,6 +10,8 @@ module HighSymmetrySites
 
 
 using NQCDynamics: AbstractSimulation, PeriodicCell, get_positions
+using NQCBase: apply_cell_boundaries!, check_atoms_in_cell
+using LinearAlgebra: norm
 
 export SlabStructure, FCC100Sites, FCC110Sites, FCC111Sites, FCC211Sites, positions_to_category, classify_every_frame
 

--- a/src/DynamicsOutputs.jl
+++ b/src/DynamicsOutputs.jl
@@ -555,11 +555,13 @@ function (output::OutputSurfaceSiteClassification)(sol, i)
     return Analysis.HighSymmetrySites.classify_every_frame(
         sol.u,
         cell,
-        output.slab_info,
-        output.fractional,
-        output.snap_to_site,
+        output.slab_info;
+        fractional = output.fractional,
+        snap_to_site = output.snap_to_site,
     )
 end
+
+export OutputSurfaceSiteClassification
 
 """
     OutputEverything(sol,i)

--- a/src/DynamicsOutputs.jl
+++ b/src/DynamicsOutputs.jl
@@ -537,6 +537,30 @@ end
 
 export OutputNoise
 
+struct OutputSurfaceSiteClassification
+    slab_info::Analysis.HighSymmetrySites.SlabStructure
+    fractional::Bool
+    snap_to_site::Float64
+end
+function OutputSurfaceSiteClassification(slab_info::Analysis.HighSymmetrySites.SlabStructure; fractional=false, snap_to_sites=0.03)
+    return OutputSurfaceSiteClassification(
+        slab_info,
+        fractional,
+        snap_to_sites
+    )
+end
+
+function (output::OutputSurfaceSiteClassification)(sol, i)
+    cell = sol.prob.p.cell # Simulation needs to have an associated PeriodicCell
+    return Analysis.HighSymmetrySites.classify_every_frame(
+        sol.u,
+        cell,
+        output.slab_info,
+        output.fractional,
+        output.snap_to_site,
+    )
+end
+
 """
     OutputEverything(sol,i)
 

--- a/test/Analysis/high_symmetry.jl
+++ b/test/Analysis/high_symmetry.jl
@@ -1,0 +1,71 @@
+using Test
+using NQCDynamics
+using LinearAlgebra
+
+@testset "Surface site classification" begin
+   test_cell = PeriodicCell(I(3) .* 3) # Unit length cell
+   dummy_sites = Dict(
+    :type_1 => [
+        [0.0,0.0],
+    ],
+    :type_2 => [
+        [1.0,1.0],
+    ],
+   )
+   testing_positions = [rand(3,10) for _ in 1:4]
+   # Indices 9 and 10 are the atom to test
+   testing_positions[1][:, 9] .= [0,0,0]
+   testing_positions[1][:, 10] .= [0,0,0]
+   testing_positions[2][:, 9] .= [1,1,0]
+   testing_positions[2][:, 10] .= [1,1,0]
+   testing_positions[3][:, 9] .= [0.5,0,0]
+   testing_positions[3][:, 10] .= [0.5,0,0]
+   testing_positions[4][:, 9] .= [0.25,0,0]
+   testing_positions[4][:, 10] .= [0.25,0,0]
+   # Case 1: 0,0 should snap to site type 1
+   result_case1 = Analysis.HighSymmetrySites.positions_to_category(
+    testing_positions[1][:, 9],
+    dummy_sites,
+    PeriodicCell(I(2))
+   )
+   @test result_case1 == :type_1
+   # Case 2: 1,1 should snap to site type 2
+   result_case2 = Analysis.HighSymmetrySites.positions_to_category(
+    testing_positions[2][:, 9],
+    dummy_sites,
+    PeriodicCell(I(2))
+   )
+   @test result_case2 == :type_2
+   # Case 3: 0.5,0 should map to :other if snap_to_site isn't particularly large. 
+   result_case3 = Analysis.HighSymmetrySites.positions_to_category(
+    testing_positions[3][:, 9],
+    dummy_sites,
+    PeriodicCell(I(2))
+   )
+   @test result_case3== :other
+   # Case 4: 0.25,0 should map to site type 1 if snap_to_site is set to 0.5. 
+   result_case4 = Analysis.HighSymmetrySites.positions_to_category(
+    testing_positions[2][:, 9],
+    dummy_sites,
+    PeriodicCell(I(2)),
+    snap_to_site = 0.5,
+   )
+   @test result_case4 == :type_1
+   # Case 5: Analysing the full trajectory should give the correct results. 
+   result_case5 = Analysis.HighSymmetrySites.classify_every_frame(
+    [DynamicsVariables(v = rand(3,10), r = i) for i in testing_positions],
+    test_cell,
+    Analysis.HighSymmetrySites.SlabStructure(
+        [9,10],
+        dummy_sites,
+        [3.0,3.0,1.0],
+    ),
+    snap_to_site = 0.45,
+   )
+   for i in 1:2
+    @test result_case5[1][i] == :site_1
+    @test result_case5[2][i] == :site_2
+    @test result_case5[3][i] == :other
+    @test result_case5[4][i] == :site_1
+   end
+end

--- a/test/Analysis/high_symmetry.jl
+++ b/test/Analysis/high_symmetry.jl
@@ -16,8 +16,8 @@ using LinearAlgebra
    # Indices 9 and 10 are the atom to test
    testing_positions[1][:, 9] .= [0,0,0]
    testing_positions[1][:, 10] .= [0,0,0]
-   testing_positions[2][:, 9] .= [1,1,0]
-   testing_positions[2][:, 10] .= [1,1,0]
+   testing_positions[2][:, 9] .= [0.99,0.99,0] # Must not be 1.0 to avoid PBC translation back to 0
+   testing_positions[2][:, 10] .= [0.99,0.99,0]
    testing_positions[3][:, 9] .= [0.5,0,0]
    testing_positions[3][:, 10] .= [0.5,0,0]
    testing_positions[4][:, 9] .= [0.25,0,0]
@@ -45,7 +45,7 @@ using LinearAlgebra
    @test result_case3== :other
    # Case 4: 0.25,0 should map to site type 1 if snap_to_site is set to 0.5. 
    result_case4 = Analysis.HighSymmetrySites.positions_to_category(
-    testing_positions[2][:, 9],
+    testing_positions[4][:, 9],
     dummy_sites,
     PeriodicCell(I(2)),
     snap_to_site = 0.5,
@@ -53,7 +53,7 @@ using LinearAlgebra
    @test result_case4 == :type_1
    # Case 5: Analysing the full trajectory should give the correct results. 
    result_case5 = Analysis.HighSymmetrySites.classify_every_frame(
-    [DynamicsVariables(v = rand(3,10), r = i) for i in testing_positions],
+    [DynamicsVariables(Simulation(Atoms([:H for _ in 1:10]), Free(3); cell = test_cell), rand(3,10), i) for i in testing_positions],
     test_cell,
     Analysis.HighSymmetrySites.SlabStructure(
         [9,10],
@@ -63,9 +63,9 @@ using LinearAlgebra
     snap_to_site = 0.45,
    )
    for i in 1:2
-    @test result_case5[1][i] == :site_1
-    @test result_case5[2][i] == :site_2
-    @test result_case5[3][i] == :other
-    @test result_case5[4][i] == :site_1
+    @test result_case5[i][1] == :type_1
+    @test result_case5[i][2] == :type_2
+    @test result_case5[i][3] == :other
+    @test result_case5[i][4] == :type_1
    end
 end


### PR DESCRIPTION
#437 is horribly out of sync, so here's a new PR instead. 

This PR adds an Analysis submodule HighSymmetrySites, which can be used to relate positions of adsorbates within a Periodic Cell to high-symmetry sites on the cell.

ToDo:

 - [ ] Document trajectory analysis.
 - [x] Ensure API docs automatically generate properly
 - [x] Unit tests functioning