### PR TITLE
Decoherence fix for IESH

### DIFF
--- a/src/DynamicsMethods/SurfaceHoppingMethods/decoherence_corrections.jl
+++ b/src/DynamicsMethods/SurfaceHoppingMethods/decoherence_corrections.jl
@@ -37,3 +37,15 @@ function apply_decoherence_correction!(
     ψ[occupied_state] = Cₘ * sqrt((1 - unoccupied_state_norm) / abs2(Cₘ))
     return nothing
 end
+
+"""
+Löwdin symmetric orthonormalization via SVD.
+ψ: M×N matrix of N electron orbitals in an M-dimensional basis.
+Replaces ψ with the closest orthonormal matrix (Frobenius norm),
+i.e. Ψ_orth = U * Vᴴ from the thin SVD Ψ = U Σ Vᴴ.
+"""
+function lowdin_orthonormalize!(ψ::AbstractMatrix{<:Complex})
+    F = svd(ψ)
+    ψ .= F.U * F.Vt
+    return ψ
+end

--- a/src/DynamicsMethods/SurfaceHoppingMethods/decoherence_corrections.jl
+++ b/src/DynamicsMethods/SurfaceHoppingMethods/decoherence_corrections.jl
@@ -1,3 +1,4 @@
+using LinearAlgebra
 
 struct DecoherenceCorrectionNone end
 apply_decoherence_correction!(args...) = nothing

--- a/src/DynamicsMethods/SurfaceHoppingMethods/iesh.jl
+++ b/src/DynamicsMethods/SurfaceHoppingMethods/iesh.jl
@@ -438,6 +438,12 @@ function iesh_apply_decoherence_correction_edc!(integrator)
     @views for (i, state) in enumerate(sim.method.state)
         apply_decoherence_correction!(ψ[:,i], sim.method.decoherence, state, dt, eigen.w, Ekin)
     end
+    C = Matrix(ψ)  
+    if norm(C'C - I) > 1e-10   # tol = 1e-10
+        lowdin_orthonormalize!(C)
+    end
+    ψ .= C 
+
 end
 
 function set_state!(container, new_state::AbstractVector, sim::AbstractSimulation{<:AbstractIESH})

--- a/src/DynamicsMethods/SurfaceHoppingMethods/iesh.jl
+++ b/src/DynamicsMethods/SurfaceHoppingMethods/iesh.jl
@@ -439,9 +439,7 @@ function iesh_apply_decoherence_correction_edc!(integrator)
         apply_decoherence_correction!(ψ[:,i], sim.method.decoherence, state, dt, eigen.w, Ekin)
     end
     C = Matrix(ψ)  
-    if norm(C'C - I) > 1e-10   # tol = 1e-10
-        lowdin_orthonormalize!(C)
-    end
+    lowdin_orthonormalize!(C)
     ψ .= C 
 
 end


### PR DESCRIPTION
Each time EDC decoherence is applied, at times during large coupling, the decoherence has a large effect. This effect leads to a drift in orthonormality between our independent electron basis therefore drifting particles from one state to another potentially leading to occupations greater than 1. The fix implemented performs orthonormalization at each timestep via an SVD decomposition to ensure this drift is countered and never builds to appreciable levels