### PR TITLE
Point DifferentialEquations.jl links at docs.sciml.ai

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@
 
 **Fast and flexible nonadiabatic molecular dynamics in Julia!**
 
--  🚗 **Fast:** uses [DifferentialEquations.jl](https://diffeq.sciml.ai/stable/) for efficient dynamics.
+-  🚗 **Fast:** uses [DifferentialEquations.jl](https://docs.sciml.ai/DiffEqDocs/stable/) for efficient dynamics.
 -  🪚 **Extensible:** plenty of room for more methods.
 - ⚛️ **Transferable:** handles both simple models and atomistic systems.
 - 👩‍🏫 **Helpful:** extended documentation with plenty of examples.
@@ -42,7 +42,7 @@
 ---
 
 With this package you can generate the initial conditions and perform the dynamics for your nonadiabatic dynamics simulations.
-Tight integration with [DifferentialEquations.jl](https://diffeq.sciml.ai/stable/)
+Tight integration with [DifferentialEquations.jl](https://docs.sciml.ai/DiffEqDocs/stable/)
 makes the implementation of new methods relatively simple since we
 build upon an already successful package providing a vast array of features.
 We hope that the package will be of use to new students and experienced researchers alike, acting as a tool for learning and for developing new methods.

--- a/docs/src/devdocs/diffeq.md
+++ b/docs/src/devdocs/diffeq.md
@@ -6,7 +6,7 @@ start_time = time()
 # DifferentialEquations.jl integration
 
 NQCDynamics.jl is built directly on top of the established
-[DifferentialEquations.jl](https://diffeq.sciml.ai/dev/index.html)
+[DifferentialEquations.jl](https://docs.sciml.ai/DiffEqDocs/dev/index.html)
 that provides a vast array of features.
 By using DifferentialEquations.jl to perform the dynamics,
 we can immediately exploit many of these features to save us a lot of work.
@@ -14,7 +14,7 @@ This page details some of the features from DifferentialEquations.jl that we hav
 
 ## [Callbacks](@id devdocs-callbacks)
 
-[Callbacks](https://diffeq.sciml.ai/dev/features/callback_functions/#callbacks) allow
+[Callbacks](https://docs.sciml.ai/DiffEqDocs/dev/features/callback_functions/#callbacks) allow
 us to introduce extra code during the dynamics without needing to meddle with the
 integration code directly.
 On the developer side, [Callbacks] is the mechanism used for the saving in the
@@ -59,7 +59,7 @@ See how the callbacks have altered the dynamics? The atom no longer leaves
 the simulation cell, and the termination caused the simulation to exit early. 
 
 The callback setup we're using is exactly that provided by DifferentialEquations.jl,
-if you want more details on callbacks, please refer to their [documentation](https://diffeq.sciml.ai/dev/features/callback_functions/#callbacks).
+if you want more details on callbacks, please refer to their [documentation](https://docs.sciml.ai/DiffEqDocs/dev/features/callback_functions/#callbacks).
 ```@setup logging
 runtime = round(time() - start_time; digits=2)
 @info "...done after $runtime s."

--- a/docs/src/devdocs/new_methods.md
+++ b/docs/src/devdocs/new_methods.md
@@ -70,7 +70,7 @@ but we also generate a random between 0 and `k`, where `k` was given as input.
 ### Implement `motion!(du, u, sim, t)`
 
 This function should fill `du` with the time-derivative of the dynamics variables `u` in the
-usual way expected by [`DifferentialEquations.jl`](https://diffeq.sciml.ai/stable/tutorials/ode_example/#Example-2:-Solving-Systems-of-Equations).
+usual way expected by [`DifferentialEquations.jl`](https://docs.sciml.ai/DiffEqDocs/stable/tutorials/ode_example/#Example-2:-Solving-Systems-of-Equations).
 We use the in-place version, where each element of `du` is filled with the time derivative of
 the correponding element in `u`.
 

--- a/docs/src/dynamicssimulations/dynamicssimulations.md
+++ b/docs/src/dynamicssimulations/dynamicssimulations.md
@@ -9,7 +9,7 @@ Performing dynamics simulations is at the core of this package's functionality
 This section of the documentation will describe how to perform dynamics simulations,
 building on the introduction from [Getting started](@ref).
 
-Since we use [DifferentialEquations](https://diffeq.sciml.ai/stable/)
+Since we use [DifferentialEquations](https://docs.sciml.ai/DiffEqDocs/stable/)
 to perform the dynamics, it is most natural
 to split up the system parameters from the dynamics variables.
 This manifests itself as two separate data types: the [`Simulation`](@ref), and the
@@ -18,7 +18,7 @@ This manifests itself as two separate data types: the [`Simulation`](@ref), and 
 !!! info
 
     If you intend to implement a new dynamics method, we recommend reading
-    [`DifferentialEquations.jl`](https://diffeq.sciml.ai/stable/) to understand
+    [`DifferentialEquations.jl`](https://docs.sciml.ai/DiffEqDocs/stable/) to understand
     more deeply how this package works.
 
 The [`Simulation`](@ref) holds all the static information about the system: the atoms,
@@ -30,7 +30,7 @@ atoms = Atoms(2000) # Single atom with mass = 2000 a.u.
 sim = Simulation{Ehrenfest}(atoms, TullyModelOne(); temperature=0, cell=InfiniteCell())
 ```
 Here we have initialised the simulation parameters, including the default temperature and cell explicitly.
-`sim` takes the place of the `p` parameter seen throughout [DifferentialEquations](https://diffeq.sciml.ai/stable/).
+`sim` takes the place of the `p` parameter seen throughout [DifferentialEquations](https://docs.sciml.ai/DiffEqDocs/stable/).
 
 ### Simulation Temperature
 
@@ -54,7 +54,7 @@ However, only one temperature should be applied to each atom in the system.
 
 ### DynamicsVariables
 
-For [DifferentialEquations](https://diffeq.sciml.ai/stable/) to allow for a wide variety of solvers, 
+For [DifferentialEquations](https://docs.sciml.ai/DiffEqDocs/stable/) to allow for a wide variety of solvers, 
 the input arrays [`DynamicsVariables`](@ref) must be [`AbstractArray`](https://docs.julialang.org/en/v1/manual/interfaces/#man-interface-array)s.
 In nonadiabatic dynamics simulations, we usually have different groups of variables that behave in particular ways.
 For example: for mapping variable methods we have positions, velocities, and two sets of mapping variables representing
@@ -63,7 +63,7 @@ the electronic degrees of freedom.
 For this purpose we use the [`ComponentVector`](https://github.com/jonniedie/ComponentArrays.jl), which allows us
 to arbitrarily partition the variables into their subgroups.
 This allows us to keep all the variables in a single array as required by
-[DifferentialEquations](https://diffeq.sciml.ai/stable/),
+[DifferentialEquations](https://docs.sciml.ai/DiffEqDocs/stable/),
 whilst still having them partitioned for convenient computation and readable code.
 
 ```@example dynamics
@@ -77,7 +77,7 @@ Since each dynamics method has a different set of variables, each method impleme
 structure.
 This helps to ensure each method follows a similar workflow, making it easy to switch between different methods.
 The output of this function takes the place of the `u` argument seen throughout
-[DifferentialEquations](https://diffeq.sciml.ai/stable/).
+[DifferentialEquations](https://docs.sciml.ai/DiffEqDocs/stable/).
 
 ### Running dynamics
 

--- a/docs/src/ensemble_simulations.md
+++ b/docs/src/ensemble_simulations.md
@@ -22,9 +22,9 @@ and changing the number of trajectories it is possible to run an ensemble of tra
 The distributions are defined such that they can be sampled to provide initial conditions for each trajectory.
 The [Storing and sampling distributions](@ref nqcdistributions) page details the format the distributions must take.
 
-Internally, the [DifferentialEquations.jl](https://diffeq.sciml.ai/stable/features/ensemble/#Performing-an-Ensemble-Simulation)
+Internally, the [DifferentialEquations.jl](https://docs.sciml.ai/DiffEqDocs/stable/features/ensemble/#Performing-an-Ensemble-Simulation)
 ensemble infrastructure is used to handle per trajectory parallelism.
-The `ensemble_algorithm` keyword takes one of the [EnsembleAlgorithms](https://diffeq.sciml.ai/stable/features/ensemble/#EnsembleAlgorithms).
+The `ensemble_algorithm` keyword takes one of the [EnsembleAlgorithms](https://docs.sciml.ai/DiffEqDocs/stable/features/ensemble/#EnsembleAlgorithms).
 To use these, you must first add `using DiffEqBase` to your script.
 
 ## Example
@@ -104,7 +104,7 @@ plot(ensemble, :OutputDiabaticPopulation)
 This workflow can be applied for any of the quantities defined in the [`DynamicsOutputs`](@ref NQCDynamics.DynamicsOutputs) submodule.
 If we want a more complex output, such as a scattering probability or a time-correlation function,
 we can provide a function to the output argument as described in the
-[DifferentialEquations.jl documentation](https://diffeq.sciml.ai/stable/features/ensemble/#Building-a-Problem).
+[DifferentialEquations.jl documentation](https://docs.sciml.ai/DiffEqDocs/stable/features/ensemble/#Building-a-Problem).
 The advantage of this approach is that memory can be saved by reducing the data as the trajectories accumulate,
 it also allows greater flexibility when modifying the output.
 

--- a/docs/src/getting_started.md
+++ b/docs/src/getting_started.md
@@ -52,7 +52,7 @@ with a description of how to save and load structures can be found
 This package chooses to separate the dynamical variables from the static atomic parameters
 included in the [`Atoms`](@ref NQCBase.Atoms) type.
 This allows us to easily interface with other numerical packages like
-[DifferentialEquations.jl](https://diffeq.sciml.ai/stable/) and
+[DifferentialEquations.jl](https://docs.sciml.ai/DiffEqDocs/stable/) and
 [AdvancedMH.jl](https://github.com/TuringLang/AdvancedMH.jl).
 As such, both positions and velocities are represented using Julia's standard `Array`
 type, specifically as an `Array{T,2}` or the `Matrix{T}` type, which are equivalent.

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -47,14 +47,14 @@ issue/pull request on Github!
 
 ### Dynamics with `DifferentialEquations.jl`
 
-The [`DifferentialEquations`](https://diffeq.sciml.ai/stable/) ecosystem from the
+The [`DifferentialEquations`](https://docs.sciml.ai/DiffEqDocs/stable/) ecosystem from the
 [SciML organisation](https://github.com/SciML/) provides a large library of integration
 algorithms along with a simple interface for implementing new algorithms that can be tailored
 for specific nonadiabatic dynamics methods.
 Further, they provide helpful utilities for introducing discontinuities through the 
-[callback interface](https://diffeq.sciml.ai/stable/features/callback_functions/#Using-Callbacks)
+[callback interface](https://docs.sciml.ai/DiffEqDocs/stable/features/callback_functions/#Using-Callbacks)
 or handling many trajectories at once to obtain ensemble averaged observables with
-the [ensemble interface](https://diffeq.sciml.ai/stable/features/ensemble/).
+the [ensemble interface](https://docs.sciml.ai/DiffEqDocs/stable/features/ensemble/).
 We can take advantage of these utilities by basing our dynamics setup on this framework
 which significantly simplifies the implementation of new methods.
 

--- a/src/DynamicsMethods/DynamicsMethods.jl
+++ b/src/DynamicsMethods/DynamicsMethods.jl
@@ -2,16 +2,16 @@
 This module contains functions and types necessary for performing
 nonadiabatic molecular dynamics.
 
-Dynamics is performed using [`DifferentialEquations.jl`](https://diffeq.sciml.ai/stable/).
+Dynamics is performed using [`DifferentialEquations.jl`](https://docs.sciml.ai/DiffEqDocs/stable/).
 As such, this module is centered around the implementation of the functions
 necessary to integrate the dynamics.
 
 For deterministic Hamiltonian methods, the central function is [`DynamicsMethods.motion!`](@ref),
 which is the inplace form of the function
-to be integrated by [`DifferentialEquations.jl`](https://diffeq.sciml.ai/stable/).
+to be integrated by [`DifferentialEquations.jl`](https://docs.sciml.ai/DiffEqDocs/stable/).
 
 Further, methods that have discontinuities, such as surface hopping, use the
-[callback interface](https://diffeq.sciml.ai/stable/features/callback_functions/#callbacks)
+[callback interface](https://docs.sciml.ai/DiffEqDocs/stable/features/callback_functions/#callbacks)
 provided by `DifferentialEquations.jl`.
 """
 module DynamicsMethods


### PR DESCRIPTION
Fixes #504.

Swaps the `diffeq.sciml.ai` prefix for `docs.sciml.ai/DiffEqDocs`, 22 links across 8 files. Checked all 10 distinct URLs return 200 after the swap.
